### PR TITLE
Errors on the main run function will send the error to the upper scope

### DIFF
--- a/nae-native/src/window.rs
+++ b/nae-native/src/window.rs
@@ -96,7 +96,7 @@ impl BaseWindow for Window {
     }
 }
 
-pub fn run<A, S, F, D>(mut app: A, mut state: S, mut update: F, mut draw: D)
+pub fn run<A, S, F, D>(mut app: A, mut state: S, mut update: F, mut draw: D) -> Result<(), String>
 where
     A: BaseApp<System = System> + 'static,
     S: 'static,
@@ -225,6 +225,8 @@ where
         *control = ControlFlow::WaitUntil(time);
         //            *control = ControlFlow::Poll;
     });
+
+    Ok(())
 }
 
 trait ToNaeValue {

--- a/nae-web/src/window.rs
+++ b/nae-web/src/window.rs
@@ -326,7 +326,7 @@ fn fullscreen_cb(win: &Window) -> Rc<RefCell<Fn()>> {
     }))
 }
 
-pub fn run<A, S, F, D>(mut app: A, mut state: S, mut update: F, mut draw: D)
+pub fn run<A, S, F, D>(mut app: A, mut state: S, mut update: F, mut draw: D) -> Result<(), String>
 where
     A: BaseApp<System = System> + 'static,
     S: 'static,
@@ -345,7 +345,7 @@ where
         &app.system().window.canvas,
         &mut mouse_ctx,
         fullscreen_cb.clone(),
-    );
+    )?;
 
     let mut keyboard_ctx = KeyboardContext::new();
     enable_keyboard_events(
@@ -353,17 +353,17 @@ where
         &app.system().window.canvas,
         &mut keyboard_ctx,
         fullscreen_cb.clone(),
-    );
+    )?;
 
     if app.system().window.resizable {
         enable_resize_event(
             events.clone(),
             &mut app.system().window,
             fullscreen_cb.clone(),
-        );
+        )?;
     }
 
-    enable_fullscreen_event(events.clone(), &mut app.system().window);
+    enable_fullscreen_event(events.clone(), &mut app.system().window)?;
 
     //Store the ref to the mouse context to avoid drop the closures, another option could be use forget but seems more clean.
     app.system().mouse_ctx = Some(mouse_ctx);
@@ -390,6 +390,8 @@ where
 
     let win = web_sys::window().unwrap();
     request_animation_frame(win, cb_copy.borrow().as_ref().unwrap());
+
+    Ok(())
 }
 
 fn enable_fullscreen_event(

--- a/src/app.rs
+++ b/src/app.rs
@@ -140,7 +140,7 @@ impl<S> AppBuilder<S> {
             move |mut app, mut state| {
                 draw_cb(&mut app, &mut state);
             },
-        );
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR exposes the error of the run function to the sup scope. This is useful on a web backend where some of the events can fail before the program starts. For the winit backend this is not important because the thread will be blocked once the event loop starts never reaching the return. 