### PR TITLE
Fix the shader version for OpenGL ES 2.0

### DIFF
--- a/nae-glow/src/shader.rs
+++ b/nae-glow/src/shader.rs
@@ -171,13 +171,15 @@ fn source_with_header(source: &str) -> String {
         return String::from(source);
     }
 
-    let is_gl_es =
-        cfg!(target_arch = "wasm32") || cfg!(target_os = "ios") || cfg!(target_os = "android");
-    if is_gl_es {
-        format!("#version 300 es\n{}", source)
+    let version = if cfg!(target_arch = "wasm32") {
+        "300 es"
+    } else if cfg!(target_os = "ios") || cfg!(target_os = "android") {
+        "100"
     } else {
-        format!("#version 410\n{}", source)
-    }
+        "410"
+    };
+
+    format!("#version {}\n{}", version, source)
 }
 
 fn create_shader(gl: &GlContext, typ: u32, source: &str) -> Result<ShaderKey, String> {


### PR DESCRIPTION
This PR changes the shader version for mobile devices using OpenGL ES 2.0 from `GLSL 300 es` to `GLSL 100`.