### PR TITLE
Added support for Instancing rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,9 +787,9 @@ checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
 
 [[package]]
 name = "glow"
-version = "0.6.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1625b792e2f9267116dd41eb7d325e0ea2572ceba5069451906745e04f852f33"
+checksum = "4f04649123493bc2483cbef4daddb45d40bbdae5adb221a63a23efdb0cc99520"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2025,9 +2025,12 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "slotmap"
-version = "0.4.0"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c46a3482db8f247956e464d783693ece164ca056e6e67563ee5505bdb86452cd"
+checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ without worrying too much about platform-specific code.
 The main goal is to provide a set of APIs and tools that can be used to create your project in an ergonomic manner without
 enforcing any structure or pattern, always trying to stay out of your way.
 
-## Quick Example
+## Examples
 
-Check the [live demos](https://nazariglez.github.io/notan-web/).
+* [Online demos](https://nazariglez.github.io/notan-web/).
 
 #### Do you want to open a window?
 
@@ -153,12 +153,7 @@ Sure! Check the [examples folder](examples). You will find there a few of them f
 
 ## Installation
 
-Make sure that you have `CMake` installed, because the shaders are compiled at compilation time. And we need CMake to convert them from `glsl 450`
-to any version needed.
-
-And then, just add `notan` to your project from [crates.io](https://crates.io). The `main` branch should always be the latest version on `crates.io`.
-
-Eventually we'll use [naga](https://github.com/gfx-rs/naga) to compile shaders avoiding *non-Rust* dependencies.
+Add `notan` to your project from [crates.io](https://crates.io). The `main` branch should always be the latest version on `crates.io`.
 
 ## WebAssembly
 
@@ -203,12 +198,8 @@ but Notan should help with most of them.
 - Web Browsers (`wasm32`) - WebGL2
 - Window - OpenGL 3.3
 - MacOS - OpenGL 3.3
-- Linux - OpenGL 3.3 (Untested, but should work)
-
-Adding `backends` for **iOS** and **Android** is something that will happen eventually because supporting them is a priority.
 
 The current graphics backend in place for these platforms is using [glow.rs](https://github.com/grovesNL/glow) which allow us to target WebGl2, GL and GL ES easily.
-Adding [wgpu.rs](https://wgpu.rs/) would be great, but I don't have the knowledge to do that right now. Any help with that will be really appreciated.
 
 ## Performance
 
@@ -249,10 +240,11 @@ not been too much opinionated about how to do it, with multiple platforms suppor
 
 I felt that it was a tricky thing to find until I found [Haxe](https://haxe.org/) and [Kha](https://kha.tech/), the perfect match.
 However, I did not like a few things about the build system, the lack of tools and IDEs, and how the language itself does some things.
-So, after a while I decided to start looking again, and I saw that **Rust** had a great **WebAssembly** compiler among other targets.
+So, after a while I decided to start looking again, and I saw that **Rust** had a great **WebAssembly** compiler among other targets, 
+and check all those boxes.
 
 For the last three years, I have been working on this project in different repositories with different names and multiple "start-over" times.
-It was my place to learn Rust and OpenGL, my hobby and my sandbox.
+It was my place to learn Rust and OpenGL, my hobby and sandbox.
 
 However, I feel that it could be useful for more people than me in the current state.
 

--- a/crates/notan_app/src/empty.rs
+++ b/crates/notan_app/src/empty.rs
@@ -120,6 +120,8 @@ impl DeviceBackend for EmptyDeviceBackend {
         Ok(self.id_count)
     }
 
+    fn set_buffer_data(&mut self, _id: u64, _data: &[u8]) {}
+
     fn render(&mut self, commands: &[Commands], _target: Option<u64>) {
         commands.iter().for_each(|cmd| log::info!("{:?}", cmd));
     }

--- a/crates/notan_app/src/empty.rs
+++ b/crates/notan_app/src/empty.rs
@@ -101,7 +101,11 @@ impl DeviceBackend for EmptyDeviceBackend {
         Ok(self.id_count)
     }
 
-    fn create_vertex_buffer(&mut self) -> Result<u64, String> {
+    fn create_vertex_buffer(
+        &mut self,
+        _attrs: &[VertexAttr],
+        _step_mode: VertexStepMode,
+    ) -> Result<u64, String> {
         self.id_count += 1;
         Ok(self.id_count)
     }

--- a/crates/notan_app/src/graphics.rs
+++ b/crates/notan_app/src/graphics.rs
@@ -122,6 +122,12 @@ impl Graphics {
     pub fn render_to(&mut self, target: &RenderTexture, renderer: &dyn GfxRenderer) {
         renderer.render(&mut self.device, &mut self.extensions, Some(target));
     }
+
+    /// Upload the buffer data to the GPU
+    #[inline]
+    pub fn set_buffer_data<T: BufferDataType>(&mut self, buffer: &Buffer, data: &[T]) {
+        self.device.set_buffer_data(buffer, data);
+    }
 }
 
 impl std::ops::Deref for Graphics {

--- a/crates/notan_app/src/graphics.rs
+++ b/crates/notan_app/src/graphics.rs
@@ -83,8 +83,8 @@ impl Graphics {
 
     /// Creates a vertex buffer builder
     #[inline]
-    pub fn create_vertex_buffer(&mut self) -> BufferBuilder<f32> {
-        BufferBuilder::new(&mut self.device, BufferUsage::Vertex, None)
+    pub fn create_vertex_buffer(&mut self) -> VertexBufferBuilder {
+        VertexBufferBuilder::new(&mut self.device)
     }
 
     /// Creates a index buffer builder

--- a/crates/notan_app/src/graphics.rs
+++ b/crates/notan_app/src/graphics.rs
@@ -89,14 +89,14 @@ impl Graphics {
 
     /// Creates a index buffer builder
     #[inline]
-    pub fn create_index_buffer(&mut self) -> BufferBuilder<u32> {
-        BufferBuilder::new(&mut self.device, BufferUsage::Index, None)
+    pub fn create_index_buffer(&mut self) -> IndexBufferBuilder {
+        IndexBufferBuilder::new(&mut self.device)
     }
 
     /// Creates a uniform buffer builder
     #[inline]
-    pub fn create_uniform_buffer(&mut self, slot: u32, name: &str) -> BufferBuilder<f32> {
-        BufferBuilder::new(&mut self.device, BufferUsage::Uniform(slot), Some(name))
+    pub fn create_uniform_buffer(&mut self, slot: u32, name: &str) -> UniformBufferBuilder {
+        UniformBufferBuilder::new(&mut self.device, slot, name)
     }
 
     /// Update the texture data

--- a/crates/notan_draw/src/batch.rs
+++ b/crates/notan_draw/src/batch.rs
@@ -45,19 +45,21 @@ impl Batch {
 
         //compute indices
         let last_index = (self.vertices.len() / offset) as u32;
-        self.indices.reserve(self.indices.len() + indices.len());
         self.indices.extend(indices.iter().map(|i| i + last_index));
 
         //compute vertices
-        self.vertices.reserve(self.vertices.len() + vertices.len());
-        (0..vertices.len()).step_by(offset).for_each(|i| {
-            let start = i + 2;
-            let end = i + offset - 1;
-            let xyz = matrix * Vec3::new(vertices[i], vertices[i + 1], 1.0);
-            self.vertices.extend(&[xyz.x, xyz.y]); //pos
-            self.vertices.extend(&vertices[start..end]); //pipeline attrs and rgb
-            self.vertices.push(vertices[i + offset - 1] * alpha); //alpha
-        });
+        vertices
+            .iter()
+            .enumerate()
+            .step_by(offset)
+            .for_each(|(i, _)| {
+                let start = i + 2;
+                let end = i + offset - 1;
+                let xyz = matrix * Vec3::new(vertices[i], vertices[i + 1], 1.0);
+                self.vertices.extend(&[xyz.x, xyz.y]); //pos
+                self.vertices.extend(&vertices[start..end]); //pipeline attrs and rgb
+                self.vertices.push(vertices[i + offset - 1] * alpha); //alpha
+            });
     }
 
     fn offset(&self) -> usize {

--- a/crates/notan_draw/src/batch.rs
+++ b/crates/notan_draw/src/batch.rs
@@ -25,7 +25,7 @@ pub(crate) struct Batch {
     pub vertices: Vec<f32>,
     pub indices: Vec<u32>,
     pub pipeline: Option<Pipeline>,
-    pub uniform_buffers: Option<Vec<Buffer<f32>>>,
+    pub uniform_buffers: Option<Vec<Buffer>>,
     pub blend_mode: BlendMode,
     pub is_mask: bool,
     pub masking: bool,

--- a/crates/notan_draw/src/custom_pipeline.rs
+++ b/crates/notan_draw/src/custom_pipeline.rs
@@ -4,7 +4,7 @@ use notan_graphics::prelude::*;
 #[derive(Default, Clone, Debug)]
 pub(crate) struct CustomPipeline {
     pub pipeline: Option<Pipeline>,
-    pub uniforms: Option<Vec<Buffer<f32>>>,
+    pub uniforms: Option<Vec<Buffer>>,
 }
 
 impl CustomPipeline {
@@ -57,7 +57,7 @@ pub struct CustomPipelineBuilder<'a> {
     draw: &'a mut Draw,
     typ: CustomPipelineType,
     pipeline: Option<&'a Pipeline>,
-    uniforms: Option<Vec<&'a Buffer<f32>>>,
+    uniforms: Option<Vec<&'a Buffer>>,
     removing: bool,
 }
 
@@ -77,7 +77,7 @@ impl<'a> CustomPipelineBuilder<'a> {
         self
     }
 
-    pub fn uniform_buffer(&mut self, buffer: &'a Buffer<f32>) -> &mut Self {
+    pub fn uniform_buffer(&mut self, buffer: &'a Buffer) -> &mut Self {
         let uniforms = self.uniforms.get_or_insert(vec![]);
         uniforms.push(buffer);
         self

--- a/crates/notan_draw/src/draw.rs
+++ b/crates/notan_draw/src/draw.rs
@@ -80,8 +80,8 @@ impl Draw {
                 }
 
                 //Reserve the space for the mask batches
-                let new_capacity = self.batches.len() + m.batches.len() + 1;
-                self.batches.reserve(new_capacity);
+                // let new_capacity = self.batches.len() + m.batches.len() + 1;
+                // self.batches.reserve(new_capacity);
                 self.batches.extend(m.batches.iter().map(|batch| {
                     let mut b = batch.clone();
                     b.is_mask = true;
@@ -390,6 +390,13 @@ fn needs_new_batch<I: DrawInfo, F: Fn(&Batch, &I) -> bool>(
                     return true; // different blend mode
                 }
             }
+
+            // TODO check this... windows drop fps dramatically without this limit
+            // if cfg!(not(target_os = "osx")) {
+            //     if b.indices.len() + info.indices().len() >= u16::MAX as usize {
+            //         return true;
+            //     }
+            // }
 
             check_type(b, info)
         }

--- a/crates/notan_draw/src/images/painter.rs
+++ b/crates/notan_draw/src/images/painter.rs
@@ -58,6 +58,7 @@ pub fn create_image_pipeline(
             VertexAttr::new(1, VertexFormat::Float2),
             VertexAttr::new(2, VertexFormat::Float4),
         ],
+        VertexStepMode::Vertex,
         PipelineOptions {
             color_blend: Some(BlendMode::NORMAL),
             ..Default::default()

--- a/crates/notan_draw/src/images/painter.rs
+++ b/crates/notan_draw/src/images/painter.rs
@@ -58,7 +58,6 @@ pub fn create_image_pipeline(
             VertexAttr::new(1, VertexFormat::Float2),
             VertexAttr::new(2, VertexFormat::Float4),
         ],
-        VertexStepMode::Vertex,
         PipelineOptions {
             color_blend: Some(BlendMode::NORMAL),
             ..Default::default()
@@ -80,7 +79,15 @@ impl ImagePainter {
         let pipeline = create_image_pipeline(device, None)?;
 
         Ok(Self {
-            vbo: device.create_vertex_buffer(vec![])?,
+            vbo: device.create_vertex_buffer(
+                vec![],
+                &[
+                    VertexAttr::new(0, VertexFormat::Float2),
+                    VertexAttr::new(1, VertexFormat::Float2),
+                    VertexAttr::new(2, VertexFormat::Float4),
+                ],
+                VertexStepMode::Vertex,
+            )?,
             ebo: device.create_index_buffer(vec![])?,
             ubo: device.create_uniform_buffer(0, "Locals", vec![0.0; 16])?,
             pipeline,

--- a/crates/notan_draw/src/images/painter.rs
+++ b/crates/notan_draw/src/images/painter.rs
@@ -66,21 +66,27 @@ pub fn create_image_pipeline(
 }
 
 pub(crate) struct ImagePainter {
-    vbo: VertexBuffer,
-    ebo: IndexBuffer,
-    ubo: UniformBuffer,
+    vbo: Buffer,
+    ebo: Buffer,
+    ubo: Buffer,
     pipeline: Pipeline,
+    vertices: Vec<f32>,
+    indices: Vec<u32>,
+    uniforms: [f32; 16],
     count_vertices: usize,
     count_indices: usize,
+    dirty_buffer: bool,
 }
 
 impl ImagePainter {
     pub fn new(device: &mut Device) -> Result<Self, String> {
         let pipeline = create_image_pipeline(device, None)?;
 
+        let uniforms = [0.0; 16];
+
         Ok(Self {
             vbo: device.create_vertex_buffer(
-                vec![],
+                None,
                 &[
                     VertexAttr::new(0, VertexFormat::Float2),
                     VertexAttr::new(1, VertexFormat::Float2),
@@ -88,11 +94,15 @@ impl ImagePainter {
                 ],
                 VertexStepMode::Vertex,
             )?,
-            ebo: device.create_index_buffer(vec![])?,
-            ubo: device.create_uniform_buffer(0, "Locals", vec![0.0; 16])?,
+            ebo: device.create_index_buffer(None)?,
+            ubo: device.create_uniform_buffer(0, "Locals", Some(&uniforms))?,
             pipeline,
+            vertices: vec![],
+            indices: vec![],
+            uniforms,
             count_indices: 0,
             count_vertices: 0,
+            dirty_buffer: false,
         })
     }
 
@@ -103,36 +113,38 @@ impl ImagePainter {
             let len = (self.count_vertices / self.pipeline.offset()) as u32;
             let offset = self.count_indices;
 
-            {
-                let mut data = self.ebo.data_ptr().write();
-                data.extend(batch.indices.iter().map(|i| i + len));
-                self.count_indices = data.len();
-            }
+            self.indices.extend(batch.indices.iter().map(|i| i + len));
+            self.count_indices = self.indices.len();
 
-            {
-                let mut data = self.vbo.data_ptr().write();
-                data.extend(&batch.vertices);
-                self.count_vertices = data.len();
-            }
+            self.vertices.extend(&batch.vertices);
+            self.count_vertices = self.vertices.len();
 
-            {
-                self.ubo
-                    .data_mut()
-                    .copy_from_slice(&projection.to_cols_array());
-            }
+            self.uniforms.copy_from_slice(&projection.to_cols_array());
 
             renderer.bind_texture(0, texture);
             renderer.bind_vertex_buffer(&self.vbo);
             renderer.bind_index_buffer(&self.ebo);
             renderer.bind_uniform_buffer(&self.ubo);
             renderer.draw(offset as _, batch.indices.len() as _);
+
+            self.dirty_buffer = true;
+        }
+    }
+
+    #[inline]
+    pub fn upload_buffers(&mut self, device: &mut Device) {
+        if self.dirty_buffer {
+            self.dirty_buffer = false;
+            device.set_buffer_data(&self.vbo, &self.vertices);
+            device.set_buffer_data(&self.ebo, &self.indices);
+            device.set_buffer_data(&self.ubo, &self.uniforms);
         }
     }
 
     pub fn clear(&mut self) {
         self.count_vertices = 0;
         self.count_indices = 0;
-        self.vbo.data_ptr().write().clear();
-        self.ebo.data_ptr().write().clear();
+        self.vertices.clear();
+        self.indices.clear();
     }
 }

--- a/crates/notan_draw/src/manager.rs
+++ b/crates/notan_draw/src/manager.rs
@@ -181,6 +181,11 @@ fn process_draw(
     }
 
     manager.renderer.end();
+
+    manager.image_painter.upload_buffers(device);
+    manager.shape_painter.upload_buffers(device);
+    manager.pattern_painter.upload_buffers(device);
+    manager.text_painter.upload_buffers(device);
 }
 
 fn override_pipeline_options(

--- a/crates/notan_draw/src/patterns/painter.rs
+++ b/crates/notan_draw/src/patterns/painter.rs
@@ -65,6 +65,7 @@ pub fn create_pattern_pipeline(
             VertexAttr::new(2, VertexFormat::Float4),
             VertexAttr::new(3, VertexFormat::Float4),
         ],
+        VertexStepMode::Vertex,
         PipelineOptions {
             color_blend: Some(BlendMode::NORMAL),
             ..Default::default()

--- a/crates/notan_draw/src/patterns/painter.rs
+++ b/crates/notan_draw/src/patterns/painter.rs
@@ -65,7 +65,6 @@ pub fn create_pattern_pipeline(
             VertexAttr::new(2, VertexFormat::Float4),
             VertexAttr::new(3, VertexFormat::Float4),
         ],
-        VertexStepMode::Vertex,
         PipelineOptions {
             color_blend: Some(BlendMode::NORMAL),
             ..Default::default()
@@ -87,7 +86,16 @@ impl PatternPainter {
         let pipeline = create_pattern_pipeline(device, None)?;
 
         Ok(Self {
-            vbo: device.create_vertex_buffer(vec![])?,
+            vbo: device.create_vertex_buffer(
+                vec![],
+                &[
+                    VertexAttr::new(0, VertexFormat::Float2),
+                    VertexAttr::new(1, VertexFormat::Float2),
+                    VertexAttr::new(2, VertexFormat::Float4),
+                    VertexAttr::new(3, VertexFormat::Float4),
+                ],
+                VertexStepMode::Vertex,
+            )?,
             ebo: device.create_index_buffer(vec![])?,
             ubo: device.create_uniform_buffer(0, "Locals", vec![0.0; 16])?,
             pipeline,

--- a/crates/notan_draw/src/shapes/painter.rs
+++ b/crates/notan_draw/src/shapes/painter.rs
@@ -49,6 +49,7 @@ pub fn create_shape_pipeline(
             VertexAttr::new(0, VertexFormat::Float2),
             VertexAttr::new(1, VertexFormat::Float4),
         ],
+        VertexStepMode::Vertex,
         PipelineOptions {
             color_blend: Some(BlendMode::NORMAL),
             ..Default::default()

--- a/crates/notan_draw/src/shapes/painter.rs
+++ b/crates/notan_draw/src/shapes/painter.rs
@@ -57,32 +57,42 @@ pub fn create_shape_pipeline(
 }
 
 pub(crate) struct ShapePainter {
-    vbo: Buffer<f32>,
-    ebo: Buffer<u32>,
-    ubo: Buffer<f32>,
+    vbo: Buffer,
+    ebo: Buffer,
+    ubo: Buffer,
     pipeline: Pipeline,
+    vertices: Vec<f32>,
+    indices: Vec<u32>,
+    uniforms: [f32; 16],
     count_vertices: usize,
     count_indices: usize,
+    dirty_buffer: bool,
 }
 
 impl ShapePainter {
     pub fn new(device: &mut Device) -> Result<Self, String> {
         let pipeline = create_shape_pipeline(device, None)?;
 
+        let uniforms = [0.0; 16];
+
         Ok(Self {
             vbo: device.create_vertex_buffer(
-                vec![],
+                None,
                 &[
                     VertexAttr::new(0, VertexFormat::Float2),
                     VertexAttr::new(1, VertexFormat::Float4),
                 ],
                 VertexStepMode::Vertex,
             )?,
-            ebo: device.create_index_buffer(vec![])?,
-            ubo: device.create_uniform_buffer(0, "Locals", vec![0.0; 16])?,
+            ebo: device.create_index_buffer(None)?,
+            ubo: device.create_uniform_buffer(0, "Locals", Some(&uniforms))?,
             pipeline,
+            vertices: vec![],
+            indices: vec![],
+            uniforms,
             count_indices: 0,
             count_vertices: 0,
+            dirty_buffer: false,
         })
     }
 
@@ -98,35 +108,36 @@ impl ShapePainter {
             let len = (self.count_vertices / self.pipeline.offset()) as u32;
             let offset = self.count_indices;
 
-            {
-                let mut data = self.ebo.data_ptr().write();
-                data.extend(batch.indices.iter().map(|i| i + len));
-                self.count_indices = data.len();
-            }
+            self.indices.extend(batch.indices.iter().map(|i| i + len));
+            self.count_indices = self.indices.len();
 
-            {
-                let mut data = self.vbo.data_ptr().write();
-                data.extend(&batch.vertices);
-                self.count_vertices = data.len();
-            }
+            self.vertices.extend(&batch.vertices);
+            self.count_vertices = self.vertices.len();
 
-            {
-                self.ubo
-                    .data_mut()
-                    .copy_from_slice(&projection.to_cols_array());
-            }
+            self.uniforms.copy_from_slice(&projection.to_cols_array());
 
             renderer.bind_vertex_buffer(&self.vbo);
             renderer.bind_index_buffer(&self.ebo);
             renderer.bind_uniform_buffer(&self.ubo);
             renderer.draw(offset as _, batch.indices.len() as _);
+            self.dirty_buffer = true;
+        }
+    }
+
+    #[inline]
+    pub fn upload_buffers(&mut self, device: &mut Device) {
+        if self.dirty_buffer {
+            self.dirty_buffer = false;
+            device.set_buffer_data(&self.vbo, &self.vertices);
+            device.set_buffer_data(&self.ebo, &self.indices);
+            device.set_buffer_data(&self.ubo, &self.uniforms);
         }
     }
 
     pub fn clear(&mut self) {
         self.count_vertices = 0;
         self.count_indices = 0;
-        self.vbo.data_ptr().write().clear();
-        self.ebo.data_ptr().write().clear();
+        self.vertices.clear();
+        self.indices.clear();
     }
 }

--- a/crates/notan_draw/src/shapes/painter.rs
+++ b/crates/notan_draw/src/shapes/painter.rs
@@ -49,7 +49,6 @@ pub fn create_shape_pipeline(
             VertexAttr::new(0, VertexFormat::Float2),
             VertexAttr::new(1, VertexFormat::Float4),
         ],
-        VertexStepMode::Vertex,
         PipelineOptions {
             color_blend: Some(BlendMode::NORMAL),
             ..Default::default()
@@ -71,7 +70,14 @@ impl ShapePainter {
         let pipeline = create_shape_pipeline(device, None)?;
 
         Ok(Self {
-            vbo: device.create_vertex_buffer(vec![])?,
+            vbo: device.create_vertex_buffer(
+                vec![],
+                &[
+                    VertexAttr::new(0, VertexFormat::Float2),
+                    VertexAttr::new(1, VertexFormat::Float4),
+                ],
+                VertexStepMode::Vertex,
+            )?,
             ebo: device.create_index_buffer(vec![])?,
             ubo: device.create_uniform_buffer(0, "Locals", vec![0.0; 16])?,
             pipeline,

--- a/crates/notan_draw/src/texts/painter.rs
+++ b/crates/notan_draw/src/texts/painter.rs
@@ -66,7 +66,15 @@ pub(crate) struct TextPainter {
 impl TextPainter {
     pub fn new(device: &mut Device) -> Result<Self, String> {
         let pipeline = create_text_pipeline(device, None)?;
-        let vbo = device.create_vertex_buffer(vec![])?;
+        let vbo = device.create_vertex_buffer(
+            vec![],
+            &[
+                VertexAttr::new(0, VertexFormat::Float2),
+                VertexAttr::new(1, VertexFormat::Float2),
+                VertexAttr::new(2, VertexFormat::Float4),
+            ],
+            VertexStepMode::Vertex,
+        )?;
         let ebo = device.create_index_buffer(vec![])?;
         let ubo = device.create_uniform_buffer(0, "Locals", vec![0.0; 16])?;
 
@@ -195,7 +203,6 @@ pub fn create_text_pipeline(
             VertexAttr::new(1, VertexFormat::Float2),
             VertexAttr::new(2, VertexFormat::Float4),
         ],
-        VertexStepMode::Vertex,
         PipelineOptions {
             color_blend: Some(BlendMode::NORMAL),
             ..Default::default()

--- a/crates/notan_draw/src/texts/painter.rs
+++ b/crates/notan_draw/src/texts/painter.rs
@@ -195,6 +195,7 @@ pub fn create_text_pipeline(
             VertexAttr::new(1, VertexFormat::Float2),
             VertexAttr::new(2, VertexFormat::Float4),
         ],
+        VertexStepMode::Vertex,
         PipelineOptions {
             color_blend: Some(BlendMode::NORMAL),
             ..Default::default()

--- a/crates/notan_egui/src/extension.rs
+++ b/crates/notan_egui/src/extension.rs
@@ -165,8 +165,7 @@ impl EguiExtension {
             .create_texture(TextureInfo {
                 width: width as _,
                 height: height as _,
-                format: TextureFormat::Rgba,
-                internal_format: TextureFormat::Rgba,
+                format: TextureFormat::Rgba32,
                 min_filter: TextureFilter::Linear,
                 mag_filter: TextureFilter::Linear,
                 bytes: Some(pixels),

--- a/crates/notan_egui/src/extension.rs
+++ b/crates/notan_egui/src/extension.rs
@@ -2,9 +2,9 @@ use crate::context::EguiContext;
 use crate::Color32;
 use egui::TextureId;
 use notan_app::{
-    BlendFactor, BlendMode, ClearOptions, Color, Commands, Device, ExtContainer,
-    GfxExtension, GfxRenderer, Graphics, IndexBuffer, Pipeline, RenderTexture, ShaderSource,
-    Texture, TextureFilter, TextureFormat, TextureInfo, UniformBuffer, VertexBuffer, VertexFormat,
+    BlendFactor, BlendMode, ClearOptions, Color, Commands, Device, ExtContainer, GfxExtension,
+    GfxRenderer, Graphics, IndexBuffer, Pipeline, RenderTexture, ShaderSource, Texture,
+    TextureFilter, TextureFormat, TextureInfo, UniformBuffer, VertexBuffer, VertexFormat,
 };
 use std::collections::HashMap;
 
@@ -123,7 +123,13 @@ impl EguiExtension {
             ))
             .build()?;
 
-        let vbo = gfx.create_vertex_buffer().build()?;
+        let vbo = gfx
+            .create_vertex_buffer()
+            .attr(0, VertexFormat::Float2)
+            .attr(1, VertexFormat::Float2)
+            .attr(2, VertexFormat::Float4)
+            .build()?;
+
         let ebo = gfx.create_index_buffer().build()?;
         let ubo = gfx
             .create_uniform_buffer(0, "Locals")

--- a/crates/notan_egui/src/extension.rs
+++ b/crates/notan_egui/src/extension.rs
@@ -2,7 +2,7 @@ use crate::context::EguiContext;
 use crate::Color32;
 use egui::TextureId;
 use notan_app::{
-    BlendFactor, BlendMode, BufferBuildImpl, ClearOptions, Color, Commands, Device, ExtContainer,
+    BlendFactor, BlendMode, ClearOptions, Color, Commands, Device, ExtContainer,
     GfxExtension, GfxRenderer, Graphics, IndexBuffer, Pipeline, RenderTexture, ShaderSource,
     Texture, TextureFilter, TextureFormat, TextureInfo, UniformBuffer, VertexBuffer, VertexFormat,
 };

--- a/crates/notan_glow/Cargo.toml
+++ b/crates/notan_glow/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 bytemuck = "1.5"
-glow = "0.6"
+glow = "0.11"
 notan_graphics = { path= "../notan_graphics" }
 hashbrown = "0.9.1"
 

--- a/crates/notan_glow/src/buffer.rs
+++ b/crates/notan_glow/src/buffer.rs
@@ -7,31 +7,50 @@ use notan_graphics::prelude::*;
 //https://sotrh.github.io/learn-wgpu/beginner/tutorial6-uniforms/#a-perspective-camera
 //https://wgld.org/d/webgl2/w009.html
 
+pub(crate) enum Kind {
+    Vertex,
+    Index,
+    Uniform(u32, String),
+}
+
 pub(crate) struct InnerBuffer {
     buffer: glow::Buffer,
 
     #[cfg(target_arch = "wasm32")]
     global_ubo: Option<Vec<u8>>, //Hack, wasm doesn't use the offset for std140
 
-    uniform_block_name: Option<String>,
-
     pub block_binded: bool,
 
     gpu_buff_size: usize,
+    draw_usage: u32,
+    draw_target: u32,
+    kind: Kind,
 }
 
 impl InnerBuffer {
     #[allow(unused_variables)] // ubo is used only on wasm32 builds
-    pub fn new(gl: &Context, ubo: bool) -> Result<Self, String> {
+    pub fn new(gl: &Context, kind: Kind, dynamic: bool) -> Result<Self, String> {
         let buffer = unsafe { gl.create_buffer()? };
 
         #[cfg(target_arch = "wasm32")]
-        let global_ubo = if ubo {
+        let global_ubo = if matches!(kind, Kind::Uniform(_, _)) {
             let max = unsafe { gl.get_parameter_i32(glow::MAX_UNIFORM_BLOCK_SIZE) } as usize;
 
             Some(vec![0; max])
         } else {
             None
+        };
+
+        let draw_usage = if dynamic {
+            glow::DYNAMIC_DRAW
+        } else {
+            glow::STATIC_DRAW
+        };
+
+        let draw_target = match kind {
+            Kind::Vertex => glow::ARRAY_BUFFER,
+            Kind::Index => glow::ELEMENT_ARRAY_BUFFER,
+            Kind::Uniform(_, _) => glow::UNIFORM_BUFFER,
         };
 
         Ok(InnerBuffer {
@@ -40,21 +59,60 @@ impl InnerBuffer {
             #[cfg(target_arch = "wasm32")]
             global_ubo,
 
-            uniform_block_name: None,
-
             block_binded: false,
 
             gpu_buff_size: 0,
+            draw_usage,
+            draw_target,
+            kind,
         })
     }
 
-    pub fn bind_block(&mut self, gl: &Context, pipeline: &InnerPipeline, slot: u32) {
+    #[inline]
+    pub fn bind(&self, gl: &Context) {
+        unsafe {
+            gl.bind_buffer(self.draw_target, Some(self.buffer));
+
+            if let Kind::Uniform(slot, _name) = &self.kind {
+                gl.bind_buffer_base(glow::UNIFORM_BUFFER, *slot, Some(self.buffer));
+            }
+        }
+    }
+
+    #[inline]
+    pub fn update(&mut self, gl: &Context, data: &[u8]) {
+        let needs_alloc = self.gpu_buff_size != data.len();
+
+        unsafe {
+            // Hack to avoid layout(std140) offset problem on webgl2
+            #[cfg(target_arch = "wasm32")]
+            let data = if matches!(self.kind, Kind::Uniform(_, _)) {
+                self.global_ubo
+                    .as_mut()
+                    .map(|ubo| {
+                        ubo[..data.len()].copy_from_slice(data);
+                        ubo.as_slice()
+                    })
+                    .unwrap_or_else(|| data)
+            } else {
+                data
+            };
+
+            if needs_alloc {
+                gl.buffer_data_u8_slice(self.draw_target, data, self.draw_usage);
+            } else {
+                gl.buffer_sub_data_u8_slice(self.draw_target, 0, data);
+            }
+        }
+    }
+
+    pub fn bind_ubo_block(&mut self, gl: &Context, pipeline: &InnerPipeline) {
         self.block_binded = true;
 
-        if let Some(name) = &self.uniform_block_name {
+        if let Kind::Uniform(slot, name) = &self.kind {
             unsafe {
                 if let Some(index) = gl.get_uniform_block_index(pipeline.program, name) {
-                    gl.uniform_block_binding(pipeline.program, index, slot as _);
+                    gl.uniform_block_binding(pipeline.program, index, *slot as _);
                 }
             }
         }
@@ -68,107 +126,10 @@ impl InnerBuffer {
     }
 
     #[inline]
-    pub fn setup_as_ubo(&mut self, gl: &Context, slot: u32, name: &str) {
-        self.uniform_block_name = Some(name.to_string());
-        self.bind_as_ubo(gl, slot);
-    }
-
-    #[inline(always)]
-    pub fn bind_as_ubo(&mut self, gl: &Context, slot: u32) {
-        unsafe {
-            gl.bind_buffer(glow::UNIFORM_BUFFER, Some(self.buffer));
-            gl.bind_buffer_base(glow::UNIFORM_BUFFER, slot, Some(self.buffer));
-        }
-    }
-
-    #[inline(always)]
-    pub fn bind_as_ubo_with_data(&mut self, gl: &Context, slot: u32, draw: &DrawType, data: &[u8]) {
-        self.bind_as_ubo(gl, slot);
-
-        #[cfg(target_arch = "wasm32")]
-        unsafe {
-            // Hack to avoid layout(std140) offset problem on webgl2
-            let ubo = self
-                .global_ubo
-                .as_mut()
-                .map(|ubo| {
-                    ubo[..data.len()].copy_from_slice(data);
-                    ubo.as_slice()
-                })
-                .unwrap_or_else(|| data);
-
-            let len = data.len();
-            if self.gpu_buff_size != len {
-                self.gpu_buff_size = len;
-                gl.buffer_data_u8_slice(glow::UNIFORM_BUFFER, ubo, draw.to_glow());
-            } else {
-                gl.buffer_sub_data_u8_slice(glow::UNIFORM_BUFFER, 0, ubo);
-            }
-        }
-
-        #[cfg(not(target_arch = "wasm32"))]
-        unsafe {
-            //https://webgl2fundamentals.org/webgl/lessons/webgl2-whats-new.html#:~:text=A%20Uniform%20Buffer%20Object%20is,blocks%20defined%20in%20a%20shader.
-            //https://stackoverflow.com/questions/44629165/bind-multiple-uniform-buffer-objects
-            let len = data.len();
-            if self.gpu_buff_size != len {
-                self.gpu_buff_size = len;
-                gl.buffer_data_u8_slice(glow::UNIFORM_BUFFER, data, draw.to_glow());
-            } else {
-                gl.buffer_sub_data_u8_slice(glow::UNIFORM_BUFFER, 0, data);
-            }
-        }
-    }
-
-    #[inline(always)]
-    pub fn bind_as_ebo(&mut self, gl: &Context) {
-        unsafe {
-            gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(self.buffer));
-        }
-    }
-
-    #[inline(always)]
-    pub fn bind_as_ebo_with_data(&mut self, gl: &Context, draw: &DrawType, data: &[u8]) {
-        self.bind_as_ebo(gl);
-
-        unsafe {
-            let len = data.len();
-            if self.gpu_buff_size != len {
-                self.gpu_buff_size = len;
-                gl.buffer_data_u8_slice(glow::ELEMENT_ARRAY_BUFFER, data, draw.to_glow());
-            } else {
-                gl.buffer_sub_data_u8_slice(glow::ELEMENT_ARRAY_BUFFER, 0, data);
-            }
-        }
-    }
-
-    #[inline]
     pub fn setup_as_vbo(&mut self, gl: &Context, attrs: VertexAttributes) {
-        self.bind_as_vbo(gl);
+        self.bind(gl);
         unsafe {
             attrs.enable(gl);
-        }
-    }
-
-    #[inline(always)]
-    pub fn bind_as_vbo(&mut self, gl: &Context) {
-        unsafe {
-            gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.buffer));
-        }
-    }
-
-    #[inline(always)]
-    pub fn bind_as_vbo_with_data(&mut self, gl: &Context, draw: &DrawType, data: &[u8]) {
-        self.bind_as_vbo(gl);
-
-        unsafe {
-            let len = data.len();
-            if self.gpu_buff_size != len {
-                self.gpu_buff_size = len;
-                gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, data, draw.to_glow());
-            } else {
-                gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, data);
-            }
         }
     }
 }

--- a/crates/notan_glow/src/buffer.rs
+++ b/crates/notan_glow/src/buffer.rs
@@ -1,8 +1,6 @@
 use crate::pipeline::VertexAttributes;
 use crate::pipeline::*;
-use crate::to_glow::*;
 use glow::*;
-use notan_graphics::prelude::*;
 
 //https://sotrh.github.io/learn-wgpu/beginner/tutorial6-uniforms/#a-perspective-camera
 //https://wgld.org/d/webgl2/w009.html

--- a/crates/notan_glow/src/buffer.rs
+++ b/crates/notan_glow/src/buffer.rs
@@ -96,7 +96,6 @@ impl InnerBuffer {
                     ubo.as_slice()
                 })
                 .unwrap_or_else(|| data);
-            // gl.buffer_data_u8_slice(glow::UNIFORM_BUFFER, ubo, draw.to_glow());
 
             let len = data.len();
             if self.gpu_buff_size != len {
@@ -163,8 +162,6 @@ impl InnerBuffer {
         self.bind_as_vbo(gl);
 
         unsafe {
-            // TODO use buffer_sub_data_u8_slice
-            // TODO https://community.khronos.org/t/bufferdata-or-buffersubdata-vbo/61674/2
             let len = data.len();
             if self.gpu_buff_size != len {
                 self.gpu_buff_size = len;

--- a/crates/notan_glow/src/buffer.rs
+++ b/crates/notan_glow/src/buffer.rs
@@ -48,7 +48,7 @@ impl InnerBuffer {
             glow::STATIC_DRAW
         };
 
-        let draw_target = match kind {
+        let draw_target = match &kind {
             Kind::Vertex(_) => glow::ARRAY_BUFFER,
             Kind::Index => glow::ELEMENT_ARRAY_BUFFER,
             Kind::Uniform(_, _) => glow::UNIFORM_BUFFER,
@@ -71,11 +71,10 @@ impl InnerBuffer {
     }
 
     #[inline]
-    pub fn bind(&mut self, gl: &Context, pipeline_id: u64) {
-        let pip = Some(pipeline_id);
-        let pipeline_changed = pip != self.last_pipeline;
+    pub fn bind(&mut self, gl: &Context, pipeline_id: Option<u64>) {
+        let pipeline_changed = pipeline_id.is_some() && pipeline_id != self.last_pipeline;
         if pipeline_changed {
-            self.last_pipeline = pip;
+            self.last_pipeline = pipeline_id;
         };
 
         unsafe {

--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -11,11 +11,11 @@ mod texture;
 mod to_glow;
 mod utils;
 
+use crate::texture::texture_format;
 use buffer::InnerBuffer;
 use pipeline::{InnerPipeline, VertexAttributes};
 use render_target::InnerRenderTexture;
 use texture::InnerTexture;
-use crate::texture::texture_format;
 
 pub struct GlowBackend {
     gl: Context,
@@ -440,7 +440,7 @@ impl DeviceBackend for GlowBackend {
                         opts.width,
                         opts.height,
                         texture_format(&opts.format), // 3d texture needs another value?
-                        glow::UNSIGNED_BYTE,   // todo UNSIGNED SHORT FOR DEPTH (3d) TEXTURES
+                        glow::UNSIGNED_BYTE,          // todo UNSIGNED SHORT FOR DEPTH (3d) TEXTURES
                         PixelUnpackData::Slice(opts.bytes),
                     );
                     // todo unbind texture?

--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -205,7 +205,7 @@ impl GlowBackend {
                 _ => {}
             }
 
-            buffer.bind(&self.gl);
+            buffer.bind(&self.gl, self.current_pipeline);
         }
     }
 
@@ -301,12 +301,10 @@ impl DeviceBackend for GlowBackend {
         attrs: &[VertexAttr],
         step_mode: VertexStepMode,
     ) -> Result<u64, String> {
-        let mut inner_buffer = InnerBuffer::new(&self.gl, Kind::Vertex, true)?;
         let (stride, inner_attrs) = get_inner_attrs(attrs);
-        inner_buffer.setup_as_vbo(
-            &self.gl,
-            VertexAttributes::new(stride, inner_attrs, step_mode),
-        );
+        let kind = Kind::Vertex(VertexAttributes::new(stride, inner_attrs, step_mode));
+        let mut inner_buffer = InnerBuffer::new(&self.gl, kind, true)?;
+        inner_buffer.bind(&self.gl, self.current_pipeline);
         self.buffer_count += 1;
         self.buffers.insert(self.buffer_count, inner_buffer);
         Ok(self.buffer_count)
@@ -314,7 +312,7 @@ impl DeviceBackend for GlowBackend {
 
     fn create_index_buffer(&mut self) -> Result<u64, String> {
         let mut inner_buffer = InnerBuffer::new(&self.gl, Kind::Index, true)?;
-        inner_buffer.bind(&self.gl);
+        inner_buffer.bind(&self.gl, self.current_pipeline);
         self.buffer_count += 1;
         self.buffers.insert(self.buffer_count, inner_buffer);
         Ok(self.buffer_count)
@@ -323,7 +321,7 @@ impl DeviceBackend for GlowBackend {
     fn create_uniform_buffer(&mut self, slot: u32, name: &str) -> Result<u64, String> {
         let mut inner_buffer =
             InnerBuffer::new(&self.gl, Kind::Uniform(slot, name.to_string()), true)?;
-        inner_buffer.bind(&self.gl);
+        inner_buffer.bind(&self.gl, self.current_pipeline);
         self.buffer_count += 1;
         self.buffers.insert(self.buffer_count, inner_buffer);
         Ok(self.buffer_count)
@@ -331,7 +329,7 @@ impl DeviceBackend for GlowBackend {
 
     fn set_buffer_data(&mut self, id: u64, data: &[u8]) {
         if let Some(buffer) = self.buffers.get_mut(&id) {
-            buffer.bind(&self.gl);
+            buffer.bind(&self.gl, self.current_pipeline);
             buffer.update(&self.gl, data);
         }
     }

--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -11,6 +11,7 @@ mod texture;
 mod to_glow;
 mod utils;
 
+use crate::buffer::Kind;
 use crate::pipeline::get_inner_attrs;
 use crate::texture::texture_format;
 use buffer::InnerBuffer;
@@ -74,6 +75,7 @@ impl GlowBackend {
         let limits = unsafe {
             Limits {
                 max_texture_size: gl.get_parameter_i32(glow::MAX_TEXTURE_SIZE) as _,
+                max_uniform_blocks: gl.get_parameter_i32(glow::MAX_UNIFORM_BLOCK_SIZE) as _,
             }
         };
 
@@ -163,6 +165,7 @@ impl GlowBackend {
             self.gl.disable(glow::SCISSOR_TEST);
             self.gl.bind_buffer(glow::ARRAY_BUFFER, None);
             self.gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, None);
+            self.gl.bind_buffer(glow::UNIFORM_BUFFER, None);
             self.gl.bind_vertex_array(None);
             self.gl.bind_framebuffer(glow::FRAMEBUFFER, None);
         }
@@ -185,43 +188,24 @@ impl GlowBackend {
         }
     }
 
-    fn bind_buffer(
-        &mut self,
-        id: u64,
-        data_wrapper: BufferDataWrapper,
-        usage: &BufferUsage,
-        draw: &DrawType,
-    ) {
+    fn bind_buffer(&mut self, id: u64, usage: &BufferUsage) {
         if let Some(buffer) = self.buffers.get_mut(&id) {
             match usage {
-                BufferUsage::Vertex => {
-                    let inner_data = data_wrapper.unwrap_f32().unwrap();
-                    let data = inner_data.read();
-                    let ptr = bytemuck::cast_slice(&data);
-                    buffer.bind_as_vbo_with_data(&self.gl, draw, ptr)
-                }
                 BufferUsage::Index => {
                     self.using_indices = true;
-                    let inner_data = data_wrapper.unwrap_u32().unwrap();
-                    let data = inner_data.read();
-                    let ptr = bytemuck::cast_slice(&data);
-                    buffer.bind_as_ebo_with_data(&self.gl, draw, ptr)
                 }
                 BufferUsage::Uniform(slot) => {
                     if !buffer.block_binded {
-                        buffer.bind_block(
+                        buffer.bind_ubo_block(
                             &self.gl,
                             self.pipelines.get(&self.current_pipeline).as_ref().unwrap(),
-                            *slot,
                         );
                     }
-
-                    let inner_data = data_wrapper.unwrap_f32().unwrap();
-                    let data = inner_data.read();
-                    let ptr = bytemuck::cast_slice(&data);
-                    buffer.bind_as_ubo_with_data(&self.gl, *slot, draw, ptr);
                 }
+                _ => {}
             }
+
+            buffer.bind(&self.gl);
         }
     }
 
@@ -317,7 +301,7 @@ impl DeviceBackend for GlowBackend {
         attrs: &[VertexAttr],
         step_mode: VertexStepMode,
     ) -> Result<u64, String> {
-        let mut inner_buffer = InnerBuffer::new(&self.gl, false)?;
+        let mut inner_buffer = InnerBuffer::new(&self.gl, Kind::Vertex, true)?;
         let (stride, inner_attrs) = get_inner_attrs(attrs);
         inner_buffer.setup_as_vbo(
             &self.gl,
@@ -329,19 +313,27 @@ impl DeviceBackend for GlowBackend {
     }
 
     fn create_index_buffer(&mut self) -> Result<u64, String> {
-        let mut inner_buffer = InnerBuffer::new(&self.gl, false)?;
-        inner_buffer.bind_as_ebo(&self.gl);
+        let mut inner_buffer = InnerBuffer::new(&self.gl, Kind::Index, true)?;
+        inner_buffer.bind(&self.gl);
         self.buffer_count += 1;
         self.buffers.insert(self.buffer_count, inner_buffer);
         Ok(self.buffer_count)
     }
 
     fn create_uniform_buffer(&mut self, slot: u32, name: &str) -> Result<u64, String> {
-        let mut inner_buffer = InnerBuffer::new(&self.gl, true)?;
-        inner_buffer.setup_as_ubo(&self.gl, slot, name);
+        let mut inner_buffer =
+            InnerBuffer::new(&self.gl, Kind::Uniform(slot, name.to_string()), true)?;
+        inner_buffer.bind(&self.gl);
         self.buffer_count += 1;
         self.buffers.insert(self.buffer_count, inner_buffer);
         Ok(self.buffer_count)
+    }
+
+    fn set_buffer_data(&mut self, id: u64, data: &[u8]) {
+        if let Some(buffer) = self.buffers.get_mut(&id) {
+            buffer.bind(&self.gl);
+            buffer.update(&self.gl, data);
+        }
     }
 
     fn render(&mut self, commands: &[Commands], target: Option<u64>) {
@@ -357,12 +349,7 @@ impl DeviceBackend for GlowBackend {
                 } => self.begin(target, color, depth, stencil),
                 End => self.end(),
                 Pipeline { id, options } => self.set_pipeline(*id, options),
-                BindBuffer {
-                    id,
-                    data,
-                    usage,
-                    draw,
-                } => self.bind_buffer(*id, data.clone(), usage, draw),
+                BindBuffer { id, usage, .. } => self.bind_buffer(*id, usage),
                 Draw { offset, count } => self.draw(*offset, *count),
                 DrawInstanced {
                     offset,

--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -205,7 +205,7 @@ impl GlowBackend {
                 _ => {}
             }
 
-            buffer.bind(&self.gl, self.current_pipeline);
+            buffer.bind(&self.gl, Some(self.current_pipeline));
         }
     }
 
@@ -304,7 +304,7 @@ impl DeviceBackend for GlowBackend {
         let (stride, inner_attrs) = get_inner_attrs(attrs);
         let kind = Kind::Vertex(VertexAttributes::new(stride, inner_attrs, step_mode));
         let mut inner_buffer = InnerBuffer::new(&self.gl, kind, true)?;
-        inner_buffer.bind(&self.gl, self.current_pipeline);
+        inner_buffer.bind(&self.gl, Some(self.current_pipeline));
         self.buffer_count += 1;
         self.buffers.insert(self.buffer_count, inner_buffer);
         Ok(self.buffer_count)
@@ -312,7 +312,7 @@ impl DeviceBackend for GlowBackend {
 
     fn create_index_buffer(&mut self) -> Result<u64, String> {
         let mut inner_buffer = InnerBuffer::new(&self.gl, Kind::Index, true)?;
-        inner_buffer.bind(&self.gl, self.current_pipeline);
+        inner_buffer.bind(&self.gl, Some(self.current_pipeline));
         self.buffer_count += 1;
         self.buffers.insert(self.buffer_count, inner_buffer);
         Ok(self.buffer_count)
@@ -321,7 +321,7 @@ impl DeviceBackend for GlowBackend {
     fn create_uniform_buffer(&mut self, slot: u32, name: &str) -> Result<u64, String> {
         let mut inner_buffer =
             InnerBuffer::new(&self.gl, Kind::Uniform(slot, name.to_string()), true)?;
-        inner_buffer.bind(&self.gl, self.current_pipeline);
+        inner_buffer.bind(&self.gl, Some(self.current_pipeline));
         self.buffer_count += 1;
         self.buffers.insert(self.buffer_count, inner_buffer);
         Ok(self.buffer_count)
@@ -329,7 +329,7 @@ impl DeviceBackend for GlowBackend {
 
     fn set_buffer_data(&mut self, id: u64, data: &[u8]) {
         if let Some(buffer) = self.buffers.get_mut(&id) {
-            buffer.bind(&self.gl, self.current_pipeline);
+            buffer.bind(&self.gl, None);
             buffer.update(&self.gl, data);
         }
     }

--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -1,4 +1,3 @@
-use crate::to_glow::ToGlow;
 use glow::*;
 use hashbrown::HashMap;
 use notan_graphics::prelude::*;
@@ -194,7 +193,7 @@ impl GlowBackend {
                 BufferUsage::Index => {
                     self.using_indices = true;
                 }
-                BufferUsage::Uniform(slot) => {
+                BufferUsage::Uniform(_slot) => {
                     if !buffer.block_binded {
                         buffer.bind_ubo_block(
                             &self.gl,

--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -15,6 +15,7 @@ use buffer::InnerBuffer;
 use pipeline::{InnerPipeline, VertexAttributes};
 use render_target::InnerRenderTexture;
 use texture::InnerTexture;
+use crate::texture::texture_format;
 
 pub struct GlowBackend {
     gl: Context,
@@ -438,7 +439,7 @@ impl DeviceBackend for GlowBackend {
                         opts.y_offset,
                         opts.width,
                         opts.height,
-                        opts.format.to_glow(), // 3d texture needs another value?
+                        texture_format(&opts.format), // 3d texture needs another value?
                         glow::UNSIGNED_BYTE,   // todo UNSIGNED SHORT FOR DEPTH (3d) TEXTURES
                         PixelUnpackData::Slice(opts.bytes),
                     );
@@ -482,7 +483,7 @@ impl DeviceBackend for GlowBackend {
                         opts.y_offset,
                         opts.width,
                         opts.height,
-                        opts.format.to_glow(),
+                        texture_format(&opts.format),
                         glow::UNSIGNED_BYTE,
                         glow::PixelPackData::Slice(bytes),
                     );

--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -30,13 +30,10 @@ pub struct GlowBackend {
     buffers: HashMap<u64, InnerBuffer>,
     textures: HashMap<u64, InnerTexture>,
     render_targets: HashMap<u64, InnerRenderTexture>,
-    // current_vertex_attrs: Option<VertexAttributes>,
     using_indices: bool,
     api_name: String,
     current_pipeline: u64,
     limits: Limits,
-
-    #[cfg(target_arch = "wasm32")]
     current_uniforms: Vec<UniformLocation>,
 }
 
@@ -89,7 +86,6 @@ impl GlowBackend {
             size: (0, 0),
             dpi: 1.0,
             pipelines: HashMap::new(),
-            // current_vertex_attrs: None,
             buffers: HashMap::new(),
             textures: HashMap::new(),
             render_targets: HashMap::new(),
@@ -97,8 +93,6 @@ impl GlowBackend {
             api_name: api.to_string(),
             current_pipeline: 0,
             limits,
-
-            #[cfg(target_arch = "wasm32")]
             current_uniforms: vec![],
         })
     }
@@ -174,7 +168,6 @@ impl GlowBackend {
         }
 
         self.using_indices = false;
-        // self.current_vertex_attrs = None;
     }
 
     fn clean_pipeline(&mut self, id: u64) {
@@ -186,14 +179,9 @@ impl GlowBackend {
     fn set_pipeline(&mut self, id: u64, options: &PipelineOptions) {
         if let Some(pip) = self.pipelines.get(&id) {
             pip.bind(&self.gl, options);
-            // self.current_vertex_attrs = Some(pip.attrs.clone());
             self.using_indices = false;
             self.current_pipeline = id;
-
-            #[cfg(target_arch = "wasm32")]
-            {
-                self.current_uniforms = pip.uniform_locations.clone();
-            }
+            self.current_uniforms = pip.uniform_locations.clone();
         }
     }
 
@@ -245,15 +233,7 @@ impl GlowBackend {
 
     #[inline(always)]
     fn get_uniform_loc<'a>(&'a self, location: &'a u32) -> &'a UniformLocation {
-        #[cfg(target_arch = "wasm32")]
-        {
-            &self.current_uniforms[*location as usize]
-        }
-
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            location
-        }
+        &self.current_uniforms[*location as usize]
     }
 
     fn clean_buffer(&mut self, id: u64) {
@@ -295,7 +275,8 @@ impl GlowBackend {
                     length,
                 );
             } else {
-                self.gl.draw_arrays_instanced(glow::TRIANGLES, offset, count, length);
+                self.gl
+                    .draw_arrays_instanced(glow::TRIANGLES, offset, count, length);
             }
         }
     }

--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -285,15 +285,18 @@ impl GlowBackend {
         }
     }
     fn draw_instanced(&mut self, offset: i32, count: i32, length: i32) {
-        debug_assert!(self.using_indices, "Cannot draw instanced without indices");
         unsafe {
-            self.gl.draw_elements_instanced(
-                glow::TRIANGLES,
-                count,
-                glow::UNSIGNED_INT,
-                offset,
-                length,
-            );
+            if self.using_indices {
+                self.gl.draw_elements_instanced(
+                    glow::TRIANGLES,
+                    count,
+                    glow::UNSIGNED_INT,
+                    offset,
+                    length,
+                );
+            } else {
+                self.gl.draw_arrays_instanced(glow::TRIANGLES, offset, count, length);
+            }
         }
     }
 }

--- a/crates/notan_glow/src/pipeline.rs
+++ b/crates/notan_glow/src/pipeline.rs
@@ -7,8 +7,6 @@ pub(crate) struct InnerPipeline {
     pub fragment: Shader,
     pub program: Program,
     pub vao: VertexArray,
-    // pub attrs: VertexAttributes,
-    #[cfg(target_arch = "wasm32")]
     pub uniform_locations: Vec<UniformLocation>,
 }
 
@@ -243,7 +241,6 @@ fn create_pipeline(
     let fragment = create_shader(gl, glow::FRAGMENT_SHADER, fragment_source)?;
     let program = create_program(gl, vertex, fragment)?;
 
-    #[cfg(target_arch = "wasm32")]
     let uniform_locations = unsafe {
         let count = gl.get_active_uniforms(program);
         (0..count)
@@ -270,15 +267,11 @@ fn create_pipeline(
         vao
     };
 
-    // let attrs = VertexAttributes::new(stride, attrs, vertex_step_mode);
-
     Ok(InnerPipeline {
         vertex,
         fragment,
         program,
         vao,
-        // attrs,
-        #[cfg(target_arch = "wasm32")]
         uniform_locations,
     })
 }

--- a/crates/notan_glow/src/pipeline.rs
+++ b/crates/notan_glow/src/pipeline.rs
@@ -234,8 +234,8 @@ fn create_pipeline(
     gl: &Context,
     vertex_source: &str,
     fragment_source: &str,
-    stride: i32,
-    attrs: Vec<InnerAttr>,
+    _stride: i32,
+    _attrs: Vec<InnerAttr>,
 ) -> Result<InnerPipeline, String> {
     let vertex = create_shader(gl, glow::VERTEX_SHADER, vertex_source)?;
     let fragment = create_shader(gl, glow::FRAGMENT_SHADER, fragment_source)?;

--- a/crates/notan_glow/src/render_target.rs
+++ b/crates/notan_glow/src/render_target.rs
@@ -67,7 +67,7 @@ unsafe fn create_fbo(
             &TextureInfo {
                 width: info.width,
                 height: info.height,
-                format: TextureFormat::Depth,
+                format: TextureFormat::Depth16,
                 min_filter: TextureFilter::Linear,
                 mag_filter: TextureFilter::Linear,
                 ..Default::default()

--- a/crates/notan_glow/src/render_target.rs
+++ b/crates/notan_glow/src/render_target.rs
@@ -68,7 +68,6 @@ unsafe fn create_fbo(
                 width: info.width,
                 height: info.height,
                 format: TextureFormat::Depth,
-                internal_format: TextureFormat::Depth,
                 min_filter: TextureFilter::Linear,
                 mag_filter: TextureFilter::Linear,
                 ..Default::default()

--- a/crates/notan_glow/src/texture.rs
+++ b/crates/notan_glow/src/texture.rs
@@ -93,7 +93,7 @@ pub(crate) unsafe fn create_texture(
         glow::CLAMP_TO_EDGE as _,
     );
 
-    let depth = TextureFormat::Depth == info.format;
+    let depth = TextureFormat::Depth16 == info.format;
     let mut data = info.bytes.as_deref();
     let mut typ = glow::UNSIGNED_BYTE;
     let mut format = texture_format(&info.format);
@@ -143,7 +143,7 @@ pub(crate) fn texture_format(tf: &TextureFormat) -> u32 {
     match tf {
         TextureFormat::Rgba32 => glow::RGBA,
         TextureFormat::R8 => glow::RED,
-        TextureFormat::Depth => glow::DEPTH_COMPONENT16,
+        TextureFormat::Depth16 => glow::DEPTH_COMPONENT16,
     }
 }
 

--- a/crates/notan_glow/src/texture.rs
+++ b/crates/notan_glow/src/texture.rs
@@ -96,7 +96,7 @@ pub(crate) unsafe fn create_texture(
     let depth = TextureFormat::Depth == info.format;
     let mut data = info.bytes.as_deref();
     let mut typ = glow::UNSIGNED_BYTE;
-    let mut format = info.format.to_glow();
+    let mut format = texture_format(&info.format);
     if depth {
         format = glow::DEPTH_COMPONENT;
         typ = glow::UNSIGNED_SHORT;
@@ -125,7 +125,7 @@ pub(crate) unsafe fn create_texture(
     gl.tex_image_2d(
         glow::TEXTURE_2D,
         0,
-        info.internal_format.to_glow() as _,
+        texture_internal_format(&info.format) as _,
         info.width,
         info.height,
         0,
@@ -137,4 +137,19 @@ pub(crate) unsafe fn create_texture(
     //TODO mipmaps? gl.generate_mipmap(glow::TEXTURE_2D);
     gl.bind_texture(glow::TEXTURE_2D, None);
     Ok(texture)
+}
+
+pub(crate) fn texture_format(tf: &TextureFormat) -> u32 {
+    match tf {
+        TextureFormat::Rgba32 => glow::RGBA,
+        TextureFormat::R8 => glow::RED,
+        TextureFormat::Depth => glow::DEPTH_COMPONENT16,
+    }
+}
+
+pub(crate) fn texture_internal_format(tf: &TextureFormat) -> u32 {
+    match tf {
+        TextureFormat::R8 => glow::R8,
+        _ => texture_format(tf),
+    }
 }

--- a/crates/notan_glow/src/to_glow.rs
+++ b/crates/notan_glow/src/to_glow.rs
@@ -108,18 +108,6 @@ impl ToGlow for VertexFormat {
     }
 }
 
-impl ToGlow for TextureFormat {
-    fn to_glow(&self) -> u32 {
-        use TextureFormat::*;
-        match self {
-            Rgba => glow::RGBA,
-            Red => glow::RED,
-            R8 => glow::R8,
-            Depth => glow::DEPTH_COMPONENT16,
-        }
-    }
-}
-
 impl ToGlow for TextureFilter {
     fn to_glow(&self) -> u32 {
         use TextureFilter::*;

--- a/crates/notan_glyph/src/pipeline.rs
+++ b/crates/notan_glyph/src/pipeline.rs
@@ -79,7 +79,15 @@ pub struct BasicPipeline {
 impl BasicPipeline {
     pub fn new(device: &mut Device) -> Result<Self, String> {
         let pipeline = create_glyph_pipeline(device, None)?;
-        let vbo = device.create_vertex_buffer(vec![])?;
+        let vbo = device.create_vertex_buffer(
+            vec![],
+            &[
+                VertexAttr::new(0, VertexFormat::Float3),
+                VertexAttr::new(1, VertexFormat::Float2),
+                VertexAttr::new(2, VertexFormat::Float4),
+            ],
+            VertexStepMode::Vertex,
+        )?;
         let ebo = device.create_index_buffer(vec![])?;
         let ubo = device.create_uniform_buffer(0, "Locals", vec![0.0; 16])?;
 
@@ -173,7 +181,6 @@ pub fn create_glyph_pipeline(
             VertexAttr::new(1, VertexFormat::Float2),
             VertexAttr::new(2, VertexFormat::Float4),
         ],
-        VertexStepMode::Vertex,
         PipelineOptions {
             color_blend: Some(BlendMode::NORMAL),
             ..Default::default()

--- a/crates/notan_glyph/src/pipeline.rs
+++ b/crates/notan_glyph/src/pipeline.rs
@@ -173,6 +173,7 @@ pub fn create_glyph_pipeline(
             VertexAttr::new(1, VertexFormat::Float2),
             VertexAttr::new(2, VertexFormat::Float4),
         ],
+        VertexStepMode::Vertex,
         PipelineOptions {
             color_blend: Some(BlendMode::NORMAL),
             ..Default::default()

--- a/crates/notan_glyph/src/pipeline.rs
+++ b/crates/notan_glyph/src/pipeline.rs
@@ -67,9 +67,9 @@ const GLYPH_FRAGMENT: ShaderSource = fragment_shader! {
 #[cfg(feature = "basic_pipeline")]
 pub struct BasicPipeline {
     pub pipeline: Pipeline,
-    pub vbo: VertexBuffer,
-    pub ebo: IndexBuffer,
-    pub ubo: UniformBuffer,
+    pub vbo: Buffer,
+    pub ebo: Buffer,
+    pub ubo: Buffer,
 
     ebo_len: usize,
     cached_size: (i32, i32),
@@ -80,7 +80,7 @@ impl BasicPipeline {
     pub fn new(device: &mut Device) -> Result<Self, String> {
         let pipeline = create_glyph_pipeline(device, None)?;
         let vbo = device.create_vertex_buffer(
-            vec![],
+            None,
             &[
                 VertexAttr::new(0, VertexFormat::Float3),
                 VertexAttr::new(1, VertexFormat::Float2),
@@ -88,8 +88,8 @@ impl BasicPipeline {
             ],
             VertexStepMode::Vertex,
         )?;
-        let ebo = device.create_index_buffer(vec![])?;
-        let ubo = device.create_uniform_buffer(0, "Locals", vec![0.0; 16])?;
+        let ebo = device.create_index_buffer(None)?;
+        let ubo = device.create_uniform_buffer(0, "Locals", Some(&[0.0; 16]))?;
 
         Ok(Self {
             pipeline,
@@ -110,7 +110,7 @@ impl GlyphPipeline for BasicPipeline {
             let ubo_data =
                 glam::Mat4::orthographic_lh(0.0, size.0 as _, size.1 as _, 0.0, -1.0, 1.0)
                     .to_cols_array();
-            self.ubo.copy(&ubo_data);
+            device.set_buffer_data(&self.ubo, &ubo_data);
             self.cached_size = size;
         }
 
@@ -152,8 +152,8 @@ impl GlyphPipeline for BasicPipeline {
             let vbo_data = vbo_data.concat();
             let ebo_data = ebo_data.concat();
             self.ebo_len = ebo_data.len();
-            self.vbo.set(&vbo_data);
-            self.ebo.set(&ebo_data);
+            device.set_buffer_data(&self.vbo, &vbo_data);
+            device.set_buffer_data(&self.ebo, &ebo_data);
         }
     }
 

--- a/crates/notan_glyph/src/plugin.rs
+++ b/crates/notan_glyph/src/plugin.rs
@@ -73,7 +73,7 @@ impl GlyphPlugin {
                             y_offset,
                             width,
                             height,
-                            format: TextureFormat::Red,
+                            format: TextureFormat::R8,
                             bytes: data,
                         },
                     );
@@ -123,7 +123,6 @@ fn create_texture(device: &mut Device, ww: u32, hh: u32) -> Result<Texture, Stri
         &vec![0; size],
         ww as _,
         hh as _,
-        TextureFormat::Red,
         TextureFormat::R8,
         TextureFilter::Linear,
         TextureFilter::Linear,

--- a/crates/notan_graphics/src/buffer.rs
+++ b/crates/notan_graphics/src/buffer.rs
@@ -132,7 +132,7 @@ where
 pub struct VertexBufferBuilder<'a> {
     device: &'a mut Device,
     data: Option<Vec<f32>>,
-    vertex_attrs: Option<Vec<VertexAttr>>,
+    vertex_attrs: Vec<VertexAttr>,
     vertex_step_mode: Option<VertexStepMode>,
 }
 
@@ -141,7 +141,7 @@ impl<'a> VertexBufferBuilder<'a> {
         Self {
             device,
             data: None,
-            vertex_attrs: None,
+            vertex_attrs: vec![],
             vertex_step_mode: None,
         }
     }
@@ -153,15 +153,7 @@ impl<'a> VertexBufferBuilder<'a> {
 
     pub fn attr(mut self, location: u32, format: VertexFormat) -> Self {
         let attr = VertexAttr::new(location, format);
-        match &mut self.vertex_attrs {
-            None => {
-                let attrs = vec![attr];
-                self.vertex_attrs = Some(attrs);
-            }
-            Some(attrs) => {
-                attrs.push(attr);
-            }
-        }
+        self.vertex_attrs.push(attr);
 
         self
     }
@@ -179,10 +171,17 @@ impl<'a> VertexBufferBuilder<'a> {
             vertex_step_mode,
         } = self;
 
-        let attrs = vertex_attrs.ok_or_else(|| "Missing vertex attributes for a VertexBuffer")?;
-        let step_mode = vertex_step_mode.unwrap_or(VertexStepMode::Vertex);
+        debug_assert!(
+            !vertex_attrs.is_empty(),
+            "Missing vertex attributes for a VertexBuffer"
+        );
 
-        device.create_vertex_buffer(data.unwrap_or_else(std::vec::Vec::new), &attrs, step_mode)
+        let step_mode = vertex_step_mode.unwrap_or(VertexStepMode::Vertex);
+        device.create_vertex_buffer(
+            data.unwrap_or_else(std::vec::Vec::new),
+            &vertex_attrs,
+            step_mode,
+        )
     }
 }
 

--- a/crates/notan_graphics/src/commands.rs
+++ b/crates/notan_graphics/src/commands.rs
@@ -48,6 +48,11 @@ pub enum Commands {
         offset: i32,
         count: i32,
     },
+    DrawInstanced {
+        offset: i32,
+        count: i32,
+        length: i32,
+    },
 }
 
 impl From<&Buffer<u32>> for Commands {

--- a/crates/notan_graphics/src/commands.rs
+++ b/crates/notan_graphics/src/commands.rs
@@ -29,7 +29,6 @@ pub enum Commands {
     },
     BindBuffer {
         id: u64,
-        data: BufferDataWrapper,
         usage: BufferUsage,
         draw: DrawType,
     },
@@ -55,22 +54,10 @@ pub enum Commands {
     },
 }
 
-impl From<&Buffer<u32>> for Commands {
-    fn from(buffer: &Buffer<u32>) -> Commands {
+impl From<&Buffer> for Commands {
+    fn from(buffer: &Buffer) -> Commands {
         Commands::BindBuffer {
             id: buffer.id(),
-            data: BufferDataWrapper::Uint32(buffer.data_ptr().clone()),
-            usage: buffer.usage,
-            draw: buffer.draw.unwrap_or(DrawType::Dynamic),
-        }
-    }
-}
-
-impl From<&Buffer<f32>> for Commands {
-    fn from(buffer: &Buffer<f32>) -> Commands {
-        Commands::BindBuffer {
-            id: buffer.id(),
-            data: BufferDataWrapper::Float32(buffer.data_ptr().clone()),
             usage: buffer.usage,
             draw: buffer.draw.unwrap_or(DrawType::Dynamic),
         }

--- a/crates/notan_graphics/src/device.rs
+++ b/crates/notan_graphics/src/device.rs
@@ -38,7 +38,11 @@ pub trait DeviceBackend {
     ) -> Result<u64, String>;
 
     /// Create a new vertex buffer object and returns the id
-    fn create_vertex_buffer(&mut self) -> Result<u64, String>;
+    fn create_vertex_buffer(
+        &mut self,
+        attrs: &[VertexAttr],
+        step_mode: VertexStepMode,
+    ) -> Result<u64, String>;
 
     /// Create a new index buffer object and returns the id
     fn create_index_buffer(&mut self) -> Result<u64, String>;
@@ -189,8 +193,13 @@ impl Device {
     }
 
     #[inline(always)]
-    pub fn create_vertex_buffer(&mut self, data: Vec<f32>) -> Result<Buffer<f32>, String> {
-        let id = self.backend.create_vertex_buffer()?;
+    pub fn create_vertex_buffer(
+        &mut self,
+        data: Vec<f32>,
+        attrs: &[VertexAttr],
+        step_mode: VertexStepMode,
+    ) -> Result<Buffer<f32>, String> {
+        let id = self.backend.create_vertex_buffer(attrs, step_mode)?;
         Ok(Buffer::new(
             id,
             data,

--- a/crates/notan_graphics/src/lib.rs
+++ b/crates/notan_graphics/src/lib.rs
@@ -17,3 +17,7 @@ pub use render_texture::*;
 pub use renderer::*;
 pub use shader::*;
 pub use texture::*;
+
+pub use notan_macro::{
+    fragment_shader, include_fragment_shader, include_vertex_shader, vertex_shader,
+};

--- a/crates/notan_graphics/src/limits.rs
+++ b/crates/notan_graphics/src/limits.rs
@@ -1,14 +1,17 @@
 // check this https://docs.rs/wgpu/0.8.1/wgpu/struct.Limits.html
 
+/// Limit are overrided by the graphic implementation
 #[derive(Debug, Clone, Copy)]
 pub struct Limits {
     pub max_texture_size: u32,
+    pub max_uniform_blocks: u32,
 }
 
 impl Default for Limits {
     fn default() -> Self {
         Self {
             max_texture_size: 8192,
+            max_uniform_blocks: 8,
         }
     }
 }

--- a/crates/notan_graphics/src/pipeline.rs
+++ b/crates/notan_graphics/src/pipeline.rs
@@ -1,4 +1,4 @@
-use crate::buffer::{VertexAttr, VertexFormat};
+use crate::buffer::{VertexAttr, VertexFormat, VertexStepMode};
 use crate::color::Color;
 use crate::device::{DropManager, ResourceId};
 use crate::{Device, ShaderSource};

--- a/crates/notan_graphics/src/pipeline.rs
+++ b/crates/notan_graphics/src/pipeline.rs
@@ -1,4 +1,4 @@
-use crate::buffer::{VertexAttr, VertexFormat, VertexStepMode};
+use crate::buffer::{VertexAttr, VertexFormat, VertexInfo, VertexStepMode};
 use crate::color::Color;
 use crate::device::{DropManager, ResourceId};
 use crate::{Device, ShaderSource};
@@ -106,9 +106,9 @@ impl<'a, 'b> PipelineBuilder<'a, 'b> {
         self
     }
 
-    /// Set the format and location for a vertex attribute
-    pub fn vertex_attr(mut self, location: u32, data: VertexFormat) -> Self {
-        self.attrs.push(VertexAttr::new(location, data));
+    /// Set the vertex structure info for a vertex buffer
+    pub fn vertex_info(mut self, info: &VertexInfo) -> Self {
+        self.attrs.extend(&info.attrs);
         self
     }
 

--- a/crates/notan_graphics/src/pipeline.rs
+++ b/crates/notan_graphics/src/pipeline.rs
@@ -1,4 +1,4 @@
-use crate::buffer::{VertexAttr, VertexFormat, VertexInfo, VertexStepMode};
+use crate::buffer::{VertexAttr, VertexInfo};
 use crate::color::Color;
 use crate::device::{DropManager, ResourceId};
 use crate::{Device, ShaderSource};

--- a/crates/notan_graphics/src/prelude.rs
+++ b/crates/notan_graphics/src/prelude.rs
@@ -8,3 +8,7 @@ pub use crate::render_texture::*;
 pub use crate::renderer::*;
 pub use crate::shader::*;
 pub use crate::texture::*;
+
+pub use notan_macro::{
+    fragment_shader, include_fragment_shader, include_vertex_shader, vertex_shader,
+};

--- a/crates/notan_graphics/src/render_texture.rs
+++ b/crates/notan_graphics/src/render_texture.rs
@@ -86,7 +86,6 @@ impl<'a> RenderTextureBuilder<'a> {
     /// Set the Texture format
     pub fn with_format(mut self, format: TextureFormat) -> Self {
         self.info.format = format;
-        self.info.internal_format = format;
         self
     }
 

--- a/crates/notan_graphics/src/renderer.rs
+++ b/crates/notan_graphics/src/renderer.rs
@@ -77,25 +77,23 @@ impl Renderer {
         });
     }
 
-    pub fn bind_vertex_buffer(&mut self, buffer: &Buffer<f32>) {
+    pub fn bind_vertex_buffer(&mut self, buffer: &Buffer) {
         self.commands.push(Commands::BindBuffer {
             id: buffer.id(),
-            data: BufferDataWrapper::Float32(buffer.data_ptr().clone()),
             usage: BufferUsage::Vertex,
             draw: buffer.draw.unwrap_or(DrawType::Dynamic),
         });
     }
 
-    pub fn bind_index_buffer(&mut self, buffer: &Buffer<u32>) {
+    pub fn bind_index_buffer(&mut self, buffer: &Buffer) {
         self.commands.push(Commands::BindBuffer {
             id: buffer.id(),
-            data: BufferDataWrapper::Uint32(buffer.data_ptr().clone()),
             usage: BufferUsage::Index,
             draw: buffer.draw.unwrap_or(DrawType::Dynamic),
         });
     }
 
-    pub fn bind_uniform_buffer(&mut self, buffer: &Buffer<f32>) {
+    pub fn bind_uniform_buffer(&mut self, buffer: &Buffer) {
         self.commands.push(buffer.into());
     }
 

--- a/crates/notan_graphics/src/renderer.rs
+++ b/crates/notan_graphics/src/renderer.rs
@@ -103,9 +103,13 @@ impl Renderer {
         self.commands.push(Commands::Draw { offset, count })
     }
 
-    /*pub fn draw_instanced(&mut self) {
-
-    }*/
+    pub fn draw_instanced(&mut self, offset: i32, count: i32, length: i32) {
+        self.commands.push(Commands::DrawInstanced {
+            offset,
+            count,
+            length,
+        })
+    }
 
     pub fn bind_texture(&mut self, location: u32, texture: &Texture) {
         self.bind_texture_slot(0, location, texture);

--- a/crates/notan_graphics/src/texture.rs
+++ b/crates/notan_graphics/src/texture.rs
@@ -273,7 +273,7 @@ impl AsRef<Texture> for Texture {
 pub enum TextureFormat {
     Rgba32,
     R8,
-    Depth,
+    Depth16,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/crates/notan_macro/src/shaders.rs
+++ b/crates/notan_macro/src/shaders.rs
@@ -134,7 +134,7 @@ fn spirv_to(spirv: &[u8], output: Output) -> Result<ShaderBytes, String> {
 fn spirv_to_glsl(spirv: &[u8], output: Output) -> Result<ShaderBytes, String> {
     let spv = read_spirv(Cursor::new(spirv)).map_err(|e| e.to_string())?;
     let glsl = compile_spirv_to_glsl(&spv, output)?;
-    println!("{:?} \n{}", output, glsl);
+    // println!("{:?} \n{}", output, glsl);
     Ok(ShaderBytes(glsl.as_bytes().to_vec()))
 }
 

--- a/crates/notan_macro/src/shaders.rs
+++ b/crates/notan_macro/src/shaders.rs
@@ -134,7 +134,7 @@ fn spirv_to(spirv: &[u8], output: Output) -> Result<ShaderBytes, String> {
 fn spirv_to_glsl(spirv: &[u8], output: Output) -> Result<ShaderBytes, String> {
     let spv = read_spirv(Cursor::new(spirv)).map_err(|e| e.to_string())?;
     let glsl = compile_spirv_to_glsl(&spv, output)?;
-    // println!("{:?} \n{}", output, glsl);
+    println!("{:?} \n{}", output, glsl);
     Ok(ShaderBytes(glsl.as_bytes().to_vec()))
 }
 

--- a/crates/notan_winit/src/window.rs
+++ b/crates/notan_winit/src/window.rs
@@ -50,6 +50,10 @@ impl WinitWindowBackend {
             .with_maximized(config.maximized)
             .with_resizable(config.resizable);
 
+        /* TODO: this should be exposed to notan to be enabled/disabled but
+        seems like is not working on mac I think... */
+        // .with_disallow_hidpi(true);
+
         if let Some((w, h)) = config.min_size {
             builder = builder.with_min_inner_size(LogicalSize::new(w, h));
         }

--- a/examples/draw_bunnymark.rs
+++ b/examples/draw_bunnymark.rs
@@ -50,7 +50,7 @@ impl State {
 
 fn init(gfx: &mut Graphics) -> State {
     let mut state = State::new(gfx);
-    state.spawn(70000);
+    state.spawn(1);
     state
 }
 

--- a/examples/draw_bunnymark.rs
+++ b/examples/draw_bunnymark.rs
@@ -50,7 +50,7 @@ impl State {
 
 fn init(gfx: &mut Graphics) -> State {
     let mut state = State::new(gfx);
-    state.spawn(5);
+    state.spawn(70000);
     state
 }
 

--- a/examples/draw_shader.rs
+++ b/examples/draw_shader.rs
@@ -31,7 +31,7 @@ const FRAGMENT: ShaderSource = notan::fragment_shader! {
 struct State {
     texture: Texture,
     pipeline: Pipeline,
-    uniforms: Buffer<f32>,
+    uniforms: Buffer,
     count: f32,
     multi: f32,
 }
@@ -55,7 +55,7 @@ fn init(gfx: &mut Graphics) -> State {
     let pipeline = create_image_pipeline(gfx, Some(&FRAGMENT)).unwrap();
     let uniforms = gfx
         .create_uniform_buffer(1, "TextureInfo")
-        .with_data(vec![5.0])
+        .with_data(&[5.0])
         .build()
         .unwrap();
 
@@ -70,13 +70,6 @@ fn init(gfx: &mut Graphics) -> State {
 
 // Change the size of the pixel effect
 fn update(app: &mut App, state: &mut State) {
-    let pixel_size = 5.0 + state.count;
-
-    {
-        let mut data = state.uniforms.data_mut();
-        data[0] = pixel_size;
-    }
-
     if state.count > 5.0 || state.count < 0.0 {
         state.multi *= -1.0;
     }
@@ -85,6 +78,9 @@ fn update(app: &mut App, state: &mut State) {
 }
 
 fn draw(gfx: &mut Graphics, state: &mut State) {
+    let pixel_size = 5.0 + state.count;
+    gfx.set_buffer_data(&state.uniforms, &[pixel_size]);
+
     let mut draw = gfx.create_draw();
     draw.clear(Color::BLACK);
 

--- a/examples/renderer_instancing.rs
+++ b/examples/renderer_instancing.rs
@@ -1,8 +1,7 @@
 use notan::prelude::*;
-use notan_log::LevelFilter;
 
 // Number of triangles to draw
-const INSTANCES: usize = 50000;
+const INSTANCES: usize = 1000;
 
 //language=glsl
 const VERT: ShaderSource = notan::vertex_shader! {
@@ -52,8 +51,7 @@ struct State {
 
 #[notan_main]
 fn main() -> Result<(), String> {
-    let lc = notan::log::LogConfig::new(LevelFilter::Debug);
-    notan::init_with(setup).set_config(lc).draw(draw).build()
+    notan::init_with(setup).draw(draw).build()
 }
 
 fn setup(gfx: &mut Graphics) -> State {
@@ -93,7 +91,6 @@ fn setup(gfx: &mut Graphics) -> State {
 }
 
 fn draw(app: &mut App, gfx: &mut Graphics, state: &mut State) {
-    notan::log::info!("fps {}", app.timer.fps());
     // Renderer pass as usual but instead of .draw uses .draw_instanced
     let mut renderer = gfx.create_renderer();
     renderer.begin(Some(&ClearOptions::new(Color::BLACK)));

--- a/examples/renderer_instancing.rs
+++ b/examples/renderer_instancing.rs
@@ -1,6 +1,7 @@
 use notan::prelude::*;
 
-const INSTANCES:usize = 30000;
+// Number of triangles to draw
+const INSTANCES: usize = 1000;
 
 //language=glsl
 const VERT: ShaderSource = notan::vertex_shader! {
@@ -9,13 +10,18 @@ const VERT: ShaderSource = notan::vertex_shader! {
     layout(location = 0) in vec2 a_pos;
     layout(location = 0) out vec3 v_color;
 
+    layout(set = 0, binding = 0) uniform Locals {
+        float count;
+    };
+
     void main() {
+        // Values to change position and color
+        float n = gl_InstanceIndex * 0.1;
+        float j = gl_VertexIndex * 0.2;
+        vec2 pos = a_pos - vec2(sin(n + count), cos(n + count)) * fract(n) * 0.9;
 
-        float value = gl_InstanceIndex * 0.1;
-        v_color = vec3(fract(value), 1.0 - fract(value), fract(value));
-
-        // vec2 pos = a_pos - vec2(sin(value), cos(value)) * 0.5;
-        gl_Position = vec4(a_pos, 0.0, 1.0);
+        v_color = vec3(fract(n - j), 1.0 - fract(n), fract(n + j));
+        gl_Position = vec4(pos, 0.0, 1.0);
     }
     "#
 };
@@ -37,28 +43,18 @@ const FRAG: ShaderSource = notan::fragment_shader! {
 
 #[derive(AppState)]
 struct State {
-    clear_options: ClearOptions,
     pipeline: Pipeline,
-    pos_vbo: VertexBuffer,
-    // color_vbo: VertexBuffer,
-    index_buffer: IndexBuffer,
+    vbo: VertexBuffer,
+    ubo: UniformBuffer,
+    count: f32,
 }
 
 #[notan_main]
 fn main() -> Result<(), String> {
-    // We'll override to debug always
-    let level = notan::log::LevelFilter::Debug;
-
-    // We use the default config with a custom log level
-    let log_config = notan::log::LogConfig::default().level(level);
-
-    notan::init_with(setup)
-        .set_config(log_config).draw(draw).build()
+    notan::init_with(setup).draw(draw).build()
 }
 
 fn setup(gfx: &mut Graphics) -> State {
-    let clear_options = ClearOptions::new(Color::new(0.1, 0.2, 0.3, 1.0));
-
     let pipeline = gfx
         .create_pipeline()
         .from(&VERT, &FRAG)
@@ -73,57 +69,41 @@ fn setup(gfx: &mut Graphics) -> State {
         0.0, 0.2
     ];
 
-    #[rustfmt::skip]
-    let colors = vec![
-        0.5, 1.0, 0.0,
-        0.0, 1.0, 0.0,
-        1.0, 0.0, 1.0,
-    ];
-
-    let indices = vec![0, 1, 2];
-
-    let pos_vbo = gfx
+    let vbo = gfx
         .create_vertex_buffer()
         .with_data(pos)
         .attr(0, VertexFormat::Float2)
         .build()
         .unwrap();
 
-    // let color_vbo = gfx
-    //     .create_vertex_buffer()
-    //     .attr(1, VertexFormat::Float3)
-    //     .step_mode(VertexStepMode::Instance)
-    //     .with_data(colors)
-    //     .build()
-    //     .unwrap();
-
-    let index_buffer = gfx
-        .create_index_buffer()
-        .with_data(indices)
+    let ubo = gfx
+        .create_uniform_buffer(0, "Locals")
+        .with_data(vec![0.0])
         .build()
         .unwrap();
 
     State {
-        clear_options,
         pipeline,
-        pos_vbo,
-        // color_vbo,
-        index_buffer,
+        vbo,
+        ubo,
+        count: 0.0,
     }
 }
 
 fn draw(app: &mut App, gfx: &mut Graphics, state: &mut State) {
-    // notan::log::info!("{}", app.timer.fps());
+    // Renderer pass as usual but instead of .draw uses .draw_instanced
     let mut renderer = gfx.create_renderer();
-
-    renderer.begin(Some(&state.clear_options));
+    renderer.begin(Some(&ClearOptions::new(Color::BLACK)));
     renderer.set_pipeline(&state.pipeline);
-    renderer.bind_vertex_buffer(&state.pos_vbo);
-    // renderer.bind_vertex_buffer(&state.color_vbo);
-    // renderer.bind_index_buffer(&state.index_buffer);
+    renderer.bind_vertex_buffer(&state.vbo);
+    renderer.bind_uniform_buffer(&state.ubo);
     renderer.draw_instanced(0, 3, INSTANCES as _);
     renderer.end();
 
+    // Render to the screen
     gfx.render(&renderer);
 
+    // Update the uniform to animate the triangles
+    state.count += 0.05 * app.timer.delta_f32();
+    state.ubo.set(&[state.count]);
 }

--- a/examples/renderer_instancing.rs
+++ b/examples/renderer_instancing.rs
@@ -1,18 +1,21 @@
 use notan::prelude::*;
 
+const INSTANCES:usize = 30000;
+
 //language=glsl
 const VERT: ShaderSource = notan::vertex_shader! {
     r#"
     #version 450
     layout(location = 0) in vec2 a_pos;
-    layout(location = 1) in vec3 a_color;
-
     layout(location = 0) out vec3 v_color;
 
     void main() {
-        vec2 pos = a_pos + gl_InstanceIndex * vec2(0.2, 0.2);
-        v_color = a_color;
-        gl_Position = vec4(pos - 0.5, 0.0, 1.0);
+
+        float value = gl_InstanceIndex * 0.1;
+        v_color = vec3(fract(value), 1.0 - fract(value), fract(value));
+
+        // vec2 pos = a_pos - vec2(sin(value), cos(value)) * 0.5;
+        gl_Position = vec4(a_pos, 0.0, 1.0);
     }
     "#
 };
@@ -37,13 +40,20 @@ struct State {
     clear_options: ClearOptions,
     pipeline: Pipeline,
     pos_vbo: VertexBuffer,
-    color_vbo: VertexBuffer,
+    // color_vbo: VertexBuffer,
     index_buffer: IndexBuffer,
 }
 
 #[notan_main]
 fn main() -> Result<(), String> {
-    notan::init_with(setup).draw(draw).build()
+    // We'll override to debug always
+    let level = notan::log::LevelFilter::Debug;
+
+    // We use the default config with a custom log level
+    let log_config = notan::log::LogConfig::default().level(level);
+
+    notan::init_with(setup)
+        .set_config(log_config).draw(draw).build()
 }
 
 fn setup(gfx: &mut Graphics) -> State {
@@ -53,15 +63,14 @@ fn setup(gfx: &mut Graphics) -> State {
         .create_pipeline()
         .from(&VERT, &FRAG)
         .vertex_attr(0, VertexFormat::Float2) // a_pos
-        .vertex_attr(1, VertexFormat::Float3) // a_color
         .build()
         .unwrap();
 
     #[rustfmt::skip]
     let pos = vec![
-        0.5, 1.0,
-        0.0, 0.0,
-        1.0, 0.0,
+       -0.2, -0.2,
+        0.2, -0.2,
+        0.0, 0.2
     ];
 
     #[rustfmt::skip]
@@ -80,13 +89,13 @@ fn setup(gfx: &mut Graphics) -> State {
         .build()
         .unwrap();
 
-    let color_vbo = gfx
-        .create_vertex_buffer()
-        .with_data(colors)
-        .attr(1, VertexFormat::Float3)
-        .step_mode(VertexStepMode::Instance)
-        .build()
-        .unwrap();
+    // let color_vbo = gfx
+    //     .create_vertex_buffer()
+    //     .attr(1, VertexFormat::Float3)
+    //     .step_mode(VertexStepMode::Instance)
+    //     .with_data(colors)
+    //     .build()
+    //     .unwrap();
 
     let index_buffer = gfx
         .create_index_buffer()
@@ -98,22 +107,23 @@ fn setup(gfx: &mut Graphics) -> State {
         clear_options,
         pipeline,
         pos_vbo,
-        color_vbo,
+        // color_vbo,
         index_buffer,
     }
 }
 
-fn draw(gfx: &mut Graphics, state: &mut State) {
+fn draw(app: &mut App, gfx: &mut Graphics, state: &mut State) {
+    // notan::log::info!("{}", app.timer.fps());
     let mut renderer = gfx.create_renderer();
 
     renderer.begin(Some(&state.clear_options));
     renderer.set_pipeline(&state.pipeline);
     renderer.bind_vertex_buffer(&state.pos_vbo);
-    renderer.bind_vertex_buffer(&state.color_vbo);
-    renderer.bind_index_buffer(&state.index_buffer);
-    renderer.draw_instanced(0, 3, 3);
-    // renderer.draw(0, 3);
+    // renderer.bind_vertex_buffer(&state.color_vbo);
+    // renderer.bind_index_buffer(&state.index_buffer);
+    renderer.draw_instanced(0, 3, INSTANCES as _);
     renderer.end();
 
     gfx.render(&renderer);
+
 }

--- a/examples/renderer_instancing.rs
+++ b/examples/renderer_instancing.rs
@@ -1,7 +1,8 @@
 use notan::prelude::*;
+use notan_log::LevelFilter;
 
 // Number of triangles to draw
-const INSTANCES: usize = 1000;
+const INSTANCES: usize = 50000;
 
 //language=glsl
 const VERT: ShaderSource = notan::vertex_shader! {
@@ -51,7 +52,8 @@ struct State {
 
 #[notan_main]
 fn main() -> Result<(), String> {
-    notan::init_with(setup).draw(draw).build()
+    let lc = notan::log::LogConfig::new(LevelFilter::Debug);
+    notan::init_with(setup).set_config(lc).draw(draw).build()
 }
 
 fn setup(gfx: &mut Graphics) -> State {
@@ -91,6 +93,7 @@ fn setup(gfx: &mut Graphics) -> State {
 }
 
 fn draw(app: &mut App, gfx: &mut Graphics, state: &mut State) {
+    notan::log::info!("fps {}", app.timer.fps());
     // Renderer pass as usual but instead of .draw uses .draw_instanced
     let mut renderer = gfx.create_renderer();
     renderer.begin(Some(&ClearOptions::new(Color::BLACK)));

--- a/examples/renderer_instancing.rs
+++ b/examples/renderer_instancing.rs
@@ -44,8 +44,8 @@ const FRAG: ShaderSource = notan::fragment_shader! {
 #[derive(AppState)]
 struct State {
     pipeline: Pipeline,
-    vbo: VertexBuffer,
-    ubo: UniformBuffer,
+    vbo: Buffer,
+    ubo: Buffer,
     count: f32,
 }
 
@@ -55,15 +55,17 @@ fn main() -> Result<(), String> {
 }
 
 fn setup(gfx: &mut Graphics) -> State {
+    let vertex_info = VertexInfo::new().attr(0, VertexFormat::Float2);
+
     let pipeline = gfx
         .create_pipeline()
         .from(&VERT, &FRAG)
-        .vertex_attr(0, VertexFormat::Float2) // a_pos
+        .vertex_info(&vertex_info)
         .build()
         .unwrap();
 
     #[rustfmt::skip]
-    let pos = vec![
+    let pos = [
        -0.2, -0.2,
         0.2, -0.2,
         0.0, 0.2
@@ -71,14 +73,14 @@ fn setup(gfx: &mut Graphics) -> State {
 
     let vbo = gfx
         .create_vertex_buffer()
-        .with_data(pos)
-        .attr(0, VertexFormat::Float2)
+        .with_info(&vertex_info)
+        .with_data(&pos)
         .build()
         .unwrap();
 
     let ubo = gfx
         .create_uniform_buffer(0, "Locals")
-        .with_data(vec![0.0])
+        .with_data(&[0.0])
         .build()
         .unwrap();
 
@@ -105,5 +107,5 @@ fn draw(app: &mut App, gfx: &mut Graphics, state: &mut State) {
 
     // Update the uniform to animate the triangles
     state.count += 0.05 * app.timer.delta_f32();
-    state.ubo.set(&[state.count]);
+    gfx.set_buffer_data(&state.ubo, &[state.count]);
 }

--- a/examples/renderer_instancing_cubes.rs
+++ b/examples/renderer_instancing_cubes.rs
@@ -144,7 +144,7 @@ fn setup(gfx: &mut Graphics) -> State {
     let mut rng = Random::default();
     let colors = (0..INSTANCES)
         .into_iter()
-        .flat_map(|n| {
+        .flat_map(|_| {
             [
                 rng.gen_range(0.0, 1.0),
                 rng.gen_range(0.0, 1.0),

--- a/examples/renderer_instancing_cubes.rs
+++ b/examples/renderer_instancing_cubes.rs
@@ -1,0 +1,222 @@
+use glam::{Mat4, Vec3};
+use notan::prelude::*;
+
+// Number of instances to draw
+const INSTANCES: usize = 15;
+
+//language=glsl
+const VERT: ShaderSource = notan::vertex_shader! {
+    r#"
+    #version 450
+    layout(location = 0) in vec4 a_position;
+    layout(location = 1) in vec4 a_color;
+
+    layout(location = 0) out vec4 v_color;
+
+    layout(set = 0, binding = 0) uniform Locals {
+        mat4 u_matrix;
+    };
+
+    mat4 transate(float x, float y) {
+        return mat4(
+            vec4(1.0, 0.0, 0.0, 1.0),
+            vec4(0.0, 1.0, 0.0, 1.0),
+            vec4(0.0, 0.0, 1.0, 1.0),
+            vec4(x, y, 1.0, 1.0)
+        );
+    }
+
+    void main() {
+        int i = gl_InstanceIndex;
+        float n = i % 2 == 0 ? i : 0;
+        float j = i % 3 == 0 ? i : 0;
+        vec4 pos = vec4(a_position.x - n * 2, a_position.y - i * 2, a_position.z - j * 2, a_position.w);
+
+        v_color = a_color;
+        gl_Position = u_matrix * pos;
+    }
+    "#
+};
+
+//language=glsl
+const FRAG: ShaderSource = notan::fragment_shader! {
+    r#"
+    #version 450
+    precision mediump float;
+
+    layout(location = 0) in vec4 v_color;
+    layout(location = 0) out vec4 color;
+
+    void main() {
+        color = v_color;
+    }
+    "#
+};
+
+#[derive(AppState)]
+struct State {
+    pipeline: Pipeline,
+    pos_vbo: VertexBuffer,
+    color_vbo: VertexBuffer,
+    ubo: UniformBuffer,
+    ebo: IndexBuffer,
+    angle: f32,
+    mvp: glam::Mat4,
+    clear_options: ClearOptions,
+}
+
+#[notan_main]
+fn main() -> Result<(), String> {
+    notan::init_with(setup).draw(draw).build()
+}
+
+fn setup(gfx: &mut Graphics) -> State {
+    let clear_options = ClearOptions {
+        color: Some(Color::new(0.1, 0.2, 0.3, 1.0)),
+        depth: Some(1.0),
+        stencil: None,
+    };
+
+    let depth_stencil = DepthStencil {
+        write: true,
+        compare: CompareMode::Less,
+    };
+
+    let pipeline = gfx
+        .create_pipeline()
+        .from(&VERT, &FRAG)
+        .vertex_attr(0, VertexFormat::Float3)
+        .vertex_attr(1, VertexFormat::Float4)
+        .with_depth_stencil(depth_stencil)
+        .build()
+        .unwrap();
+
+    #[rustfmt::skip]
+    let vertices = vec![
+        -1.0, -1.0, -1.0,
+        1.0, -1.0, -1.0,
+        1.0,  1.0, -1.0,
+        -1.0,  1.0, -1.0,
+
+        -1.0, -1.0,  1.0,
+        1.0, -1.0,  1.0,
+        1.0,  1.0,  1.0,
+        -1.0,  1.0,  1.0,
+
+        -1.0, -1.0, -1.0,
+        -1.0,  1.0, -1.0,
+        -1.0,  1.0,  1.0,
+        -1.0, -1.0,  1.0,
+
+        1.0, -1.0, -1.0,
+        1.0,  1.0, -1.0,
+        1.0,  1.0,  1.0,
+        1.0, -1.0,  1.0,
+
+        -1.0, -1.0, -1.0,
+        -1.0, -1.0,  1.0,
+        1.0, -1.0,  1.0,
+        1.0, -1.0, -1.0,
+
+        -1.0,  1.0, -1.0,
+        -1.0,  1.0,  1.0,
+        1.0,  1.0,  1.0,
+        1.0,  1.0, -1.0,
+    ];
+
+    #[rustfmt::skip]
+    let indices = vec![
+        0, 1, 2,  0, 2, 3,
+        6, 5, 4,  7, 6, 4,
+        8, 9, 10,  8, 10, 11,
+        14, 13, 12,  15, 14, 12,
+        16, 17, 18,  16, 18, 19,
+        22, 21, 20,  23, 22, 20
+    ];
+
+    // Generate 1 color per cube
+    let mut rng = Random::default();
+    let colors = (0..INSTANCES)
+        .into_iter()
+        .flat_map(|n| {
+            [
+                rng.gen_range(0.0, 1.0),
+                rng.gen_range(0.0, 1.0),
+                rng.gen_range(0.0, 1.0),
+            ]
+        })
+        .collect::<Vec<f32>>();
+
+    let projection = glam::Mat4::perspective_rh_gl(5.0, 4.0 / 3.0, 0.1, 100.0);
+    let view = Mat4::look_at_rh(
+        Vec3::new(4.0, 3.0, 3.0),
+        Vec3::new(0.0, 0.0, 0.0),
+        Vec3::new(0.0, 1.0, 0.0),
+    );
+    let mvp = Mat4::IDENTITY * projection * view;
+
+    // Postion buffer, Step mode by default is per Vertex
+    let pos_vbo = gfx
+        .create_vertex_buffer()
+        .attr(0, VertexFormat::Float3)
+        .with_data(vertices)
+        .build()
+        .unwrap();
+
+    // Color buffer, step mode changed to Instance to use 1 color of the buffer per instance
+    let color_vbo = gfx
+        .create_vertex_buffer()
+        .attr(1, VertexFormat::Float4)
+        .step_mode(VertexStepMode::Instance)
+        .with_data(colors)
+        .build()
+        .unwrap();
+
+    let ebo = gfx
+        .create_index_buffer()
+        .with_data(indices)
+        .build()
+        .unwrap();
+
+    let ubo = gfx
+        .create_uniform_buffer(0, "Locals")
+        .with_data(mvp.to_cols_array().to_vec())
+        .build()
+        .unwrap();
+
+    State {
+        pipeline,
+        pos_vbo,
+        color_vbo,
+        ubo,
+        ebo,
+        angle: 0.0,
+        mvp,
+        clear_options,
+    }
+}
+
+fn draw(app: &mut App, gfx: &mut Graphics, state: &mut State) {
+    let mut renderer = gfx.create_renderer();
+
+    state.ubo.copy(&rotated_matrix(state.mvp, state.angle));
+
+    renderer.begin(Some(&state.clear_options));
+    renderer.set_pipeline(&state.pipeline);
+    renderer.bind_uniform_buffer(&state.ubo);
+    renderer.bind_vertex_buffer(&state.pos_vbo);
+    renderer.bind_vertex_buffer(&state.color_vbo);
+    renderer.bind_index_buffer(&state.ebo);
+    renderer.draw_instanced(0, 36, 10);
+    renderer.end();
+
+    gfx.render(&renderer);
+
+    state.angle += 0.6 * app.timer.delta_f32();
+}
+
+fn rotated_matrix(base: Mat4, angle: f32) -> [f32; 16] {
+    let rot_x = Mat4::from_rotation_x(angle);
+    let rot_y = Mat4::from_rotation_y(angle);
+    (base * rot_x * rot_y).to_cols_array()
+}

--- a/examples/renderer_quad.rs
+++ b/examples/renderer_quad.rs
@@ -35,8 +35,8 @@ const FRAG: ShaderSource = notan::fragment_shader! {
 struct State {
     clear_options: ClearOptions,
     pipeline: Pipeline,
-    vertex_buffer: Buffer<f32>,
-    index_buffer: Buffer<u32>,
+    vertex_buffer: Buffer,
+    index_buffer: Buffer,
 }
 
 #[notan_main]
@@ -47,33 +47,37 @@ fn main() -> Result<(), String> {
 fn setup(gfx: &mut Graphics) -> State {
     let clear_options = ClearOptions::new(Color::new(0.1, 0.2, 0.3, 1.0));
 
-    let pipeline = gfx
-        .create_pipeline()
-        .from(&VERT, &FRAG)
-        .vertex_attr(0, VertexFormat::Float2)
-        .vertex_attr(1, VertexFormat::Float3)
-        .build()
-        .unwrap();
-
     #[rustfmt::skip]
-    let vertices = vec![
+        let vertices = [
         0.0, 1.0,   1.0, 0.2, 0.3,
         0.0, 0.0,   0.1, 1.0, 0.3,
         1.0, 0.0,   0.1, 0.2, 1.0,
         1.0, 1.0,   1.0, 1.0, 0.1,
     ];
 
-    let indices = vec![0, 1, 2, 0, 2, 3];
+    let indices = [0, 1, 2, 0, 2, 3];
+
+    let vertex_info = VertexInfo::new()
+        .attr(0, VertexFormat::Float2)
+        .attr(1, VertexFormat::Float3);
+
+    let pipeline = gfx
+        .create_pipeline()
+        .from(&VERT, &FRAG)
+        .vertex_info(&vertex_info)
+        .build()
+        .unwrap();
 
     let vertex_buffer = gfx
         .create_vertex_buffer()
-        .with_data(vertices)
+        .with_info(&vertex_info)
+        .with_data(&vertices)
         .build()
         .unwrap();
 
     let index_buffer = gfx
         .create_index_buffer()
-        .with_data(indices)
+        .with_data(&indices)
         .build()
         .unwrap();
 

--- a/examples/renderer_render_texture.rs
+++ b/examples/renderer_render_texture.rs
@@ -37,8 +37,8 @@ const FRAG: ShaderSource = notan::fragment_shader! {
 #[derive(AppState)]
 struct State {
     pipeline: Pipeline,
-    vertex_buffer: Buffer<f32>,
-    index_buffer: Buffer<u32>,
+    vertex_buffer: Buffer,
+    index_buffer: Buffer,
     texture: Texture,
     render_texture: RenderTexture,
     render_texture2: RenderTexture,
@@ -51,11 +51,14 @@ fn main() -> Result<(), String> {
 }
 
 fn setup(gfx: &mut Graphics) -> State {
+    let vertex_info = VertexInfo::new()
+        .attr(0, VertexFormat::Float3)
+        .attr(1, VertexFormat::Float2);
+
     let pipeline = gfx
         .create_pipeline()
         .from(&VERT, &FRAG)
-        .vertex_attr(0, VertexFormat::Float3)
-        .vertex_attr(1, VertexFormat::Float2)
+        .vertex_info(&vertex_info)
         .with_color_blend(BlendMode::NORMAL)
         .build()
         .unwrap();
@@ -71,7 +74,7 @@ fn setup(gfx: &mut Graphics) -> State {
     let render_texture2 = gfx.create_render_texture(width, height).build().unwrap();
 
     #[rustfmt::skip]
-    let vertices = vec![
+    let vertices = [
         //pos               //coords
         0.9,  0.9, 0.0,     1.0, 1.0,
         0.9, -0.9, 0.0,     1.0, 0.0,
@@ -80,20 +83,21 @@ fn setup(gfx: &mut Graphics) -> State {
     ];
 
     #[rustfmt::skip]
-    let indices = vec![
+    let indices = [
         0, 1, 3,
         1, 2, 3,
     ];
 
     let vertex_buffer = gfx
         .create_vertex_buffer()
-        .with_data(vertices)
+        .with_info(&vertex_info)
+        .with_data(&vertices)
         .build()
         .unwrap();
 
     let index_buffer = gfx
         .create_index_buffer()
-        .with_data(indices)
+        .with_data(&indices)
         .build()
         .unwrap();
 

--- a/examples/renderer_texture.rs
+++ b/examples/renderer_texture.rs
@@ -38,8 +38,8 @@ const FRAG: ShaderSource = notan::fragment_shader! {
 struct State {
     clear_options: ClearOptions,
     pipeline: Pipeline,
-    vertex_buffer: Buffer<f32>,
-    index_buffer: Buffer<u32>,
+    vertex_buffer: Buffer,
+    index_buffer: Buffer,
     texture: Texture,
 }
 
@@ -51,11 +51,14 @@ fn main() -> Result<(), String> {
 fn setup(gfx: &mut Graphics) -> State {
     let clear_options = ClearOptions::new(Color::new(0.1, 0.2, 0.3, 1.0));
 
+    let vertex_info = VertexInfo::new()
+        .attr(0, VertexFormat::Float3)
+        .attr(1, VertexFormat::Float2);
+
     let pipeline = gfx
         .create_pipeline()
         .from(&VERT, &FRAG)
-        .vertex_attr(0, VertexFormat::Float3)
-        .vertex_attr(1, VertexFormat::Float2)
+        .vertex_info(&vertex_info)
         .with_color_blend(BlendMode::NORMAL)
         .build()
         .unwrap();
@@ -67,7 +70,7 @@ fn setup(gfx: &mut Graphics) -> State {
         .unwrap();
 
     #[rustfmt::skip]
-    let vertices = vec![
+    let vertices = [
         //pos               //coords
         0.5,  0.5, 0.0,     1.0, 1.0,
         0.5, -0.5, 0.0,     1.0, 0.0,
@@ -76,20 +79,21 @@ fn setup(gfx: &mut Graphics) -> State {
     ];
 
     #[rustfmt::skip]
-    let indices = vec![
+    let indices = [
         0, 1, 3,
         1, 2, 3,
     ];
 
     let vertex_buffer = gfx
         .create_vertex_buffer()
-        .with_data(vertices)
+        .with_info(&vertex_info)
+        .with_data(&vertices)
         .build()
         .unwrap();
 
     let index_buffer = gfx
         .create_index_buffer()
-        .with_data(indices)
+        .with_data(&indices)
         .build()
         .unwrap();
 

--- a/examples/renderer_textured_cube.rs
+++ b/examples/renderer_textured_cube.rs
@@ -129,6 +129,8 @@ fn setup(gfx: &mut Graphics) -> State {
 
     let vertex_buffer = gfx
         .create_vertex_buffer()
+        .attr(0, VertexFormat::Float3)
+        .attr(1, VertexFormat::Float2)
         .with_data(vertices)
         .build()
         .unwrap();

--- a/examples/renderer_triangle.rs
+++ b/examples/renderer_triangle.rs
@@ -35,7 +35,7 @@ const FRAG: ShaderSource = notan::fragment_shader! {
 struct State {
     clear_options: ClearOptions,
     pipeline: Pipeline,
-    vertex_buffer: Buffer<f32>,
+    vbo: Buffer,
 }
 
 #[notan_main]
@@ -46,33 +46,35 @@ fn main() -> Result<(), String> {
 fn setup(gfx: &mut Graphics) -> State {
     let clear_options = ClearOptions::new(Color::new(0.1, 0.2, 0.3, 1.0));
 
+    let vertex_info = VertexInfo::new()
+        .attr(0, VertexFormat::Float2)
+        .attr(1, VertexFormat::Float3);
+
     let pipeline = gfx
         .create_pipeline()
         .from(&VERT, &FRAG)
-        .vertex_attr(0, VertexFormat::Float2) // a_pos
-        .vertex_attr(1, VertexFormat::Float3) // a_color
+        .vertex_info(&vertex_info)
         .build()
         .unwrap();
 
     #[rustfmt::skip]
-    let vertices = vec![
+    let vertices = [
         0.5, 1.0,   1.0, 0.2, 0.3,
         0.0, 0.0,   0.1, 1.0, 0.3,
         1.0, 0.0,   0.1, 0.2, 1.0,
     ];
 
-    let vertex_buffer = gfx
+    let vbo = gfx
         .create_vertex_buffer()
-        .with_data(vertices)
-        .attr(0, VertexFormat::Float2)
-        .attr(1, VertexFormat::Float3)
+        .with_info(&vertex_info)
+        .with_data(&vertices)
         .build()
         .unwrap();
 
     State {
         clear_options,
         pipeline,
-        vertex_buffer,
+        vbo,
     }
 }
 
@@ -81,7 +83,7 @@ fn draw(gfx: &mut Graphics, state: &mut State) {
 
     renderer.begin(Some(&state.clear_options));
     renderer.set_pipeline(&state.pipeline);
-    renderer.bind_vertex_buffer(&state.vertex_buffer);
+    renderer.bind_vertex_buffer(&state.vbo);
     renderer.draw(0, 3);
     renderer.end();
 


### PR DESCRIPTION
This PR contains a breaking change, the `VertexBuffer`, `IndexBuffer` and `UniformBuffer` were removed in favour of `Buffer`. This allows uploading the buffer data when the buffer really changes and not on each pass and removes one `RwLock`. There is a little improvement in performance which is always nice. 