### PR TITLE
Fixed and improved some low level rendering code

### DIFF
--- a/crates/notan_app/src/empty.rs
+++ b/crates/notan_app/src/empty.rs
@@ -133,6 +133,7 @@ impl DeviceBackend for EmptyDeviceBackend {
         _vertex_source: &[u8],
         _fragment_source: &[u8],
         _vertex_attrs: &[VertexAttr],
+        _texture_locations: &[(u32, String)],
         _options: PipelineOptions,
     ) -> Result<u64, String> {
         self.id_count += 1;

--- a/crates/notan_draw/src/images/painter.rs
+++ b/crates/notan_draw/src/images/painter.rs
@@ -62,6 +62,7 @@ pub fn create_image_pipeline(
         .from(&IMAGE_VERTEX, fragment)
         .with_vertex_info(&vertex_info())
         .with_color_blend(BlendMode::NORMAL)
+        .with_texture_location(0, "u_texture")
         .build()
 }
 

--- a/crates/notan_draw/src/shapes/ellipse.rs
+++ b/crates/notan_draw/src/shapes/ellipse.rs
@@ -44,7 +44,7 @@ impl Ellipse {
     }
 
     pub fn rotate_degrees(&mut self, deg: f32) -> &mut Self {
-        self.rotation = deg * notan_math::DEG_TO_RAD;
+        self.rotation = deg.to_radians();
         self
     }
 

--- a/crates/notan_draw/src/transform.rs
+++ b/crates/notan_draw/src/transform.rs
@@ -46,7 +46,7 @@ pub trait DrawTransform {
     #[inline]
     /// Set the matrix rotation using degrees
     fn rotate_degrees(&mut self, deg: f32) -> &mut Self {
-        self.rotate(deg * notan_math::DEG_TO_RAD)
+        self.rotate(deg.to_radians())
     }
 
     /// Set the matrix skew
@@ -79,7 +79,7 @@ pub trait DrawTransform {
     #[inline]
     /// Set the matrix rotation using degrees from the point given
     fn rotate_degrees_from(&mut self, point: (f32, f32), deg: f32) -> &mut Self {
-        self.rotate_from(point, deg * notan_math::DEG_TO_RAD)
+        self.rotate_from(point, deg.to_radians())
     }
 
     /// Set the matrix scale from the point given

--- a/crates/notan_egui/src/extension.rs
+++ b/crates/notan_egui/src/extension.rs
@@ -71,7 +71,7 @@ const EGUI_FRAGMENT: ShaderSource = notan_macro::fragment_shader! {
     layout(location = 1) in vec2 v_tc;
     layout(location = 2) in float v_need_gamma_fix;
 
-    layout(set = 0, binding = 0) uniform sampler2D u_sampler;
+    layout(location = 0) uniform sampler2D u_sampler;
 
     layout(location = 0) out vec4 color;
 
@@ -139,6 +139,7 @@ impl EguiExtension {
                 BlendFactor::One,
             ))
             .with_cull_mode(CullMode::None)
+            .with_texture_location(0, "u_sampler")
             .build()?;
 
         let vbo = gfx.create_vertex_buffer().with_info(&vertex_info).build()?;

--- a/crates/notan_glow/src/buffer.rs
+++ b/crates/notan_glow/src/buffer.rs
@@ -69,8 +69,9 @@ impl InnerBuffer {
     }
 
     #[inline]
-    pub fn bind(&mut self, gl: &Context, pipeline_id: Option<u64>) {
-        let pipeline_changed = pipeline_id.is_some() && pipeline_id != self.last_pipeline;
+    pub fn bind(&mut self, gl: &Context, pipeline_id: Option<u64>, reset_attrs: bool) {
+        let pipeline_changed =
+            pipeline_id.is_some() && (pipeline_id != self.last_pipeline || reset_attrs);
         if pipeline_changed {
             self.last_pipeline = pipeline_id;
         };

--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -382,7 +382,7 @@ impl DeviceBackend for GlowBackend {
     fn render(&mut self, commands: &[Commands], target: Option<u64>) {
         commands.iter().for_each(|cmd| {
             use Commands::*;
-            // log::trace!("Render cmd: {:?}", cmd);
+            // println!("Render cmd: {:?}", cmd);
 
             match cmd {
                 Begin {

--- a/crates/notan_glow/src/pipeline.rs
+++ b/crates/notan_glow/src/pipeline.rs
@@ -1,7 +1,10 @@
 use crate::to_glow::*;
 use glow::*;
-use hashbrown::{HashMap, HashSet};
+use hashbrown::HashMap;
 use notan_graphics::prelude::*;
+
+#[cfg(debug_assertions)]
+use hashbrown::HashSet;
 
 pub(crate) struct InnerPipeline {
     pub vertex: Shader,

--- a/crates/notan_glow/src/pipeline.rs
+++ b/crates/notan_glow/src/pipeline.rs
@@ -276,7 +276,7 @@ fn create_pipeline(
     #[cfg(debug_assertions)]
     let mut not_used_textures: HashSet<String> = texture_locations
         .into_iter()
-        .map(|(loc, id)| id.clone())
+        .map(|(_loc, id)| id.clone())
         .collect();
 
     let uniform_locations = unsafe {

--- a/crates/notan_glow/src/pipeline.rs
+++ b/crates/notan_glow/src/pipeline.rs
@@ -44,9 +44,13 @@ impl InnerPipeline {
     pub fn use_attrs(&mut self, buffer: u64, attrs: &VertexAttributes) -> bool {
         let mut reset = false;
         attrs.attrs.iter().for_each(|attr| {
-            if let Some(old_id) = self.attrs_bound_to.insert(attr.location, buffer) {
-                if old_id != buffer {
-                    reset = true;
+            let old = self.attrs_bound_to.insert(attr.location, buffer);
+            match old {
+                None => reset = true,
+                Some(old_id) => {
+                    if old_id != buffer {
+                        reset = true;
+                    }
                 }
             }
         });

--- a/crates/notan_glow/src/pipeline.rs
+++ b/crates/notan_glow/src/pipeline.rs
@@ -301,7 +301,7 @@ fn create_pipeline(
                             }
 
                             // register the texgture uniform loc under the new loc provided by the user
-                            texture_locations_map.insert(tloc, loc);
+                            texture_locations_map.insert(tloc, loc.clone());
                         }
 
                         Some(loc)

--- a/crates/notan_glow/src/texture.rs
+++ b/crates/notan_glow/src/texture.rs
@@ -69,13 +69,13 @@ pub(crate) unsafe fn create_texture(
     gl.tex_parameter_i32(
         glow::TEXTURE_2D,
         glow::TEXTURE_WRAP_S,
-        glow::CLAMP_TO_EDGE as _,
+        info.wrap_x.to_glow() as _,
     );
 
     gl.tex_parameter_i32(
         glow::TEXTURE_2D,
         glow::TEXTURE_WRAP_T,
-        glow::CLAMP_TO_EDGE as _,
+        info.wrap_y.to_glow() as _,
     );
 
     gl.tex_parameter_i32(
@@ -87,16 +87,6 @@ pub(crate) unsafe fn create_texture(
         glow::TEXTURE_2D,
         glow::TEXTURE_MIN_FILTER,
         info.min_filter.to_glow() as _,
-    );
-    gl.tex_parameter_i32(
-        glow::TEXTURE_2D,
-        glow::TEXTURE_WRAP_S,
-        glow::CLAMP_TO_EDGE as _,
-    );
-    gl.tex_parameter_i32(
-        glow::TEXTURE_2D,
-        glow::TEXTURE_WRAP_T,
-        glow::CLAMP_TO_EDGE as _,
     );
 
     let depth = TextureFormat::Depth16 == info.format;

--- a/crates/notan_glow/src/texture.rs
+++ b/crates/notan_glow/src/texture.rs
@@ -40,17 +40,14 @@ impl InnerTexture {
 
 #[inline]
 fn gl_slot(slot: u32) -> Result<u32, String> {
-    Ok(match slot {
-        0 => glow::TEXTURE0,
-        1 => glow::TEXTURE1,
-        2 => glow::TEXTURE2,
-        3 => glow::TEXTURE3,
-        4 => glow::TEXTURE4,
-        5 => glow::TEXTURE5,
-        6 => glow::TEXTURE6,
-        7 => glow::TEXTURE7,
-        _ => return Err(format!("Unsupported texture slot '{}'", slot)),
-    })
+    if slot < 16 {
+        Ok(glow::TEXTURE0 + slot)
+    } else {
+        Err(format!(
+            "Unsupported texture slot '{}', You can use up to 6.",
+            slot
+        ))
+    }
 }
 
 pub(crate) unsafe fn create_texture(

--- a/crates/notan_glow/src/to_glow.rs
+++ b/crates/notan_glow/src/to_glow.rs
@@ -112,6 +112,16 @@ impl ToGlow for VertexFormat {
     }
 }
 
+impl ToGlow for TextureWrap {
+    fn to_glow(&self) -> u32 {
+        use TextureWrap::*;
+        match self {
+            Clamp => glow::CLAMP_TO_EDGE,
+            Repeat => glow::REPEAT,
+        }
+    }
+}
+
 impl ToGlow for TextureFilter {
     fn to_glow(&self) -> u32 {
         use TextureFilter::*;

--- a/crates/notan_graphics/src/device.rs
+++ b/crates/notan_graphics/src/device.rs
@@ -34,6 +34,7 @@ pub trait DeviceBackend {
         vertex_source: &[u8],
         fragment_source: &[u8],
         vertex_attrs: &[VertexAttr],
+        texture_locations: &[(u32, String)],
         options: PipelineOptions,
     ) -> Result<u64, String>;
 
@@ -209,6 +210,7 @@ impl Device {
         vertex_source: &[u8],
         fragment_source: &[u8],
         vertex_attrs: &[VertexAttr],
+        texture_locations: &[(u32, String)],
         options: PipelineOptions,
     ) -> Result<Pipeline, String> {
         let stride = vertex_attrs
@@ -219,6 +221,7 @@ impl Device {
             vertex_source,
             fragment_source,
             vertex_attrs,
+            texture_locations,
             options.clone(),
         )?;
 
@@ -236,6 +239,7 @@ impl Device {
         vertex_source: &ShaderSource,
         fragment_source: &ShaderSource,
         vertex_attrs: &[VertexAttr],
+        texture_locations: &[(u32, String)],
         options: PipelineOptions,
     ) -> Result<Pipeline, String> {
         let api = self.backend.api_name();
@@ -245,7 +249,13 @@ impl Device {
         let fragment = fragment_source
             .get_source(api)
             .ok_or(format!("Fragment shader for api '{}' not available.", api))?;
-        self.inner_create_pipeline_from_raw(vertex, fragment, vertex_attrs, options)
+        self.inner_create_pipeline_from_raw(
+            vertex,
+            fragment,
+            vertex_attrs,
+            texture_locations,
+            options,
+        )
     }
 
     #[inline(always)]

--- a/crates/notan_graphics/src/texture.rs
+++ b/crates/notan_graphics/src/texture.rs
@@ -32,6 +32,8 @@ pub struct TextureInfo {
     pub format: TextureFormat,
     pub min_filter: TextureFilter,
     pub mag_filter: TextureFilter,
+    pub wrap_x: TextureWrap,
+    pub wrap_y: TextureWrap,
     pub bytes: Option<Vec<u8>>,
     pub premultiplied_alpha: bool,
 
@@ -45,6 +47,8 @@ impl Default for TextureInfo {
             format: TextureFormat::Rgba32,
             mag_filter: TextureFilter::Nearest,
             min_filter: TextureFilter::Nearest,
+            wrap_x: TextureWrap::Clamp,
+            wrap_y: TextureWrap::Clamp,
             width: 1,
             height: 1,
             bytes: None,
@@ -217,6 +221,12 @@ pub enum TextureFilter {
     Nearest,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum TextureWrap {
+    Clamp,
+    Repeat,
+}
+
 enum TextureKind<'a> {
     Texture(&'a [u8]),
     Bytes(&'a [u8]),
@@ -281,6 +291,13 @@ impl<'a, 'b> TextureBuilder<'a, 'b> {
     pub fn with_filter(mut self, min: TextureFilter, mag: TextureFilter) -> Self {
         self.info.min_filter = min;
         self.info.mag_filter = mag;
+        self
+    }
+
+    /// Set the texture wrap modes (x -> s, y -> t)
+    pub fn with_wrap(mut self, x: TextureWrap, y: TextureWrap) -> Self {
+        self.info.wrap_x = x;
+        self.info.wrap_y = y;
         self
     }
 

--- a/crates/notan_math/src/constants.rs
+++ b/crates/notan_math/src/constants.rs
@@ -1,2 +1,4 @@
+#[deprecated]
 pub const DEG_TO_RAD: f32 = std::f32::consts::PI / 180.0;
+#[deprecated]
 pub const RAD_TO_DEG: f32 = 180.0 / std::f32::consts::PI;

--- a/examples/draw_shader.rs
+++ b/examples/draw_shader.rs
@@ -10,7 +10,7 @@ const FRAGMENT: ShaderSource = notan::fragment_shader! {
     layout(location = 0) in vec2 v_uvs;
     layout(location = 1) in vec4 v_color;
 
-    layout(set = 0, binding = 0) uniform sampler2D u_texture;
+    layout(location = 0) uniform sampler2D u_texture;
     layout(set = 0, binding = 1) uniform TextureInfo {
         float u_size;
     };

--- a/examples/draw_transform.rs
+++ b/examples/draw_transform.rs
@@ -1,5 +1,5 @@
 use notan::draw::*;
-use notan::math::{Mat3, Vec2, DEG_TO_RAD};
+use notan::math::{Mat3, Vec2};
 use notan::prelude::*;
 
 const COLORS: [Color; 8] = [
@@ -36,7 +36,7 @@ fn draw(app: &mut App, gfx: &mut Graphics, state: &mut State) {
 
     // Calculate the matrix that we use for each object
     let translation = Mat3::from_translation(Vec2::new(30.0, 20.0));
-    let rotation = Mat3::from_angle(state.rot * DEG_TO_RAD);
+    let rotation = Mat3::from_angle(state.rot.to_radians());
     let matrix = translation * rotation;
 
     for (i, c) in COLORS.iter().enumerate() {

--- a/examples/draw_transform_local.rs
+++ b/examples/draw_transform_local.rs
@@ -1,5 +1,5 @@
 use notan::draw::*;
-use notan::math::{Mat3, Vec2, DEG_TO_RAD};
+use notan::math::{Mat3, Vec2};
 use notan::prelude::*;
 
 #[derive(AppState, Default)]
@@ -41,7 +41,7 @@ fn draw(app: &mut App, gfx: &mut Graphics, state: &mut State) {
 
     // Create a matrix that we can set to the next paint
     let translation = Mat3::from_translation(Vec2::new(200.0, 400.0));
-    let rotation = Mat3::from_angle(state.rot * 0.5 * DEG_TO_RAD);
+    let rotation = Mat3::from_angle(state.rot * 0.5_f32.to_radians());
     let matrix = translation * rotation;
 
     draw.rect((0.0, 0.0), (100.0, 100.0))

--- a/examples/renderer_postprocess.rs
+++ b/examples/renderer_postprocess.rs
@@ -60,7 +60,7 @@ const PIXEL_INVERT_FRAGMENT: ShaderSource = notan::fragment_shader! {
     layout(location = 0) out vec4 outColor;
     layout(location = 0) in vec2 v_texcoord;
 
-    layout(set = 0, binding = 0) uniform sampler2D u_texture;
+    layout(location = 0) uniform sampler2D u_texture;
     layout(set = 0, binding = 0) uniform Locals {
         vec2 u_tex_size;
         float u_value;
@@ -106,6 +106,7 @@ impl PostProcessTarget {
             .from(&IMAGE_VERTEX, &PIXEL_INVERT_FRAGMENT)
             .with_color_blend(BlendMode::NORMAL)
             .with_vertex_info(&vertex_info)
+            .with_texture_location(0, "u_texture")
             .build()
             .unwrap();
 

--- a/examples/renderer_render_texture.rs
+++ b/examples/renderer_render_texture.rs
@@ -27,7 +27,7 @@ const FRAG: ShaderSource = notan::fragment_shader! {
 
     layout(location = 0) out vec4 outColor;
 
-    layout(set = 0, binding = 0) uniform sampler2D u_texture;
+    layout(location = 0) uniform sampler2D u_texture;
     void main() {
         outColor = texture(u_texture, v_texcoord);
     }
@@ -60,6 +60,7 @@ fn setup(gfx: &mut Graphics) -> State {
         .from(&VERT, &FRAG)
         .with_vertex_info(&vertex_info)
         .with_color_blend(BlendMode::NORMAL)
+        .with_texture_location(0, "u_texture")
         .build()
         .unwrap();
 

--- a/examples/renderer_texture.rs
+++ b/examples/renderer_texture.rs
@@ -27,7 +27,7 @@ const FRAG: ShaderSource = notan::fragment_shader! {
 
     layout(location = 0) out vec4 outColor;
 
-    layout(set = 0, binding = 0) uniform sampler2D u_texture;
+    layout(location = 0) uniform sampler2D u_texture;
     void main() {
         outColor = texture(u_texture, v_texcoord);
     }
@@ -60,6 +60,7 @@ fn setup(gfx: &mut Graphics) -> State {
         .from(&VERT, &FRAG)
         .with_vertex_info(&vertex_info)
         .with_color_blend(BlendMode::NORMAL)
+        .with_texture_location(0, "u_texture")
         .build()
         .unwrap();
 

--- a/examples/renderer_textured_cube.rs
+++ b/examples/renderer_textured_cube.rs
@@ -30,7 +30,7 @@ const FRAG: ShaderSource = notan::fragment_shader! {
 
     layout(location = 0) out vec4 outColor;
 
-    layout(set = 0, binding = 0) uniform sampler2D u_texture;
+    layout(location = 0) uniform sampler2D u_texture;
 
     void main() {
         outColor = texture(u_texture, v_texcoord);
@@ -69,6 +69,7 @@ fn setup(gfx: &mut Graphics) -> State {
         .create_pipeline()
         .from(&VERT, &FRAG)
         .with_vertex_info(&vertex_info)
+        .with_texture_location(0, "u_texture")
         .with_depth_stencil(DepthStencil {
             write: true,
             compare: CompareMode::Less,


### PR DESCRIPTION
- VAOs doesn't keep older attribute pointers anymore after a new VAO is bind
- Textures can use Wrap modes now
- Increased textures slots per shader from 8 to 16
- Deprecated `math::DEG_TO_RAD` and `math::RAD_TO_DEG`
- Textures need to be declared on the pipeline with the location ID 