### PR TITLE
Added capture cursor feature to lock the cursor inside the window's app

### DIFF
--- a/crates/notan_app/src/backend.rs
+++ b/crates/notan_app/src/backend.rs
@@ -150,4 +150,10 @@ pub trait WindowBackend {
 
     /// Returns the current cursor icon
     fn cursor(&self) -> CursorIcon;
+
+    /// Confine the mouse on the app
+    fn set_capture_mouse(&mut self, capture: bool);
+
+    /// Returns if the mouse is confined in the app
+    fn capture_mouse(&self) -> bool;
 }

--- a/crates/notan_app/src/backend.rs
+++ b/crates/notan_app/src/backend.rs
@@ -152,8 +152,8 @@ pub trait WindowBackend {
     fn cursor(&self) -> CursorIcon;
 
     /// Confine the mouse on the app
-    fn set_capture_mouse(&mut self, capture: bool);
+    fn set_capture_cursor(&mut self, capture: bool);
 
     /// Returns if the mouse is confined in the app
-    fn capture_mouse(&self) -> bool;
+    fn capture_cursor(&self) -> bool;
 }

--- a/crates/notan_app/src/empty.rs
+++ b/crates/notan_app/src/empty.rs
@@ -60,11 +60,11 @@ impl WindowBackend for EmptyWindowBackend {
         CursorIcon::Default
     }
 
-    fn set_capture_mouse(&mut self, capture: bool) {
+    fn set_capture_cursor(&mut self, capture: bool) {
         self.caputed = capture;
     }
 
-    fn capture_mouse(&self) -> bool {
+    fn capture_cursor(&self) -> bool {
         self.caputed
     }
 }

--- a/crates/notan_app/src/empty.rs
+++ b/crates/notan_app/src/empty.rs
@@ -18,6 +18,7 @@ pub struct EmptyWindowBackend {
     size: (i32, i32),
     is_fullscreen: bool,
     lazy: bool,
+    caputed: bool,
 }
 
 impl WindowBackend for EmptyWindowBackend {
@@ -57,6 +58,14 @@ impl WindowBackend for EmptyWindowBackend {
 
     fn cursor(&self) -> CursorIcon {
         CursorIcon::Default
+    }
+
+    fn set_capture_mouse(&mut self, capture: bool) {
+        self.caputed = capture;
+    }
+
+    fn capture_mouse(&self) -> bool {
+        self.caputed
     }
 }
 

--- a/crates/notan_input/src/mouse.rs
+++ b/crates/notan_input/src/mouse.rs
@@ -2,6 +2,7 @@ use hashbrown::{HashMap, HashSet};
 use notan_core::events::Event;
 
 pub use notan_core::mouse::MouseButton;
+use notan_math::Vec2;
 
 #[derive(Default)]
 /// Represent the mouse data
@@ -16,6 +17,8 @@ pub struct Mouse {
     pub down: HashMap<MouseButton, f32>,
     /// released buttons
     pub released: HashSet<MouseButton>,
+    /// wheel delta
+    pub wheel_delta: Vec2,
 }
 
 impl Mouse {
@@ -122,6 +125,9 @@ impl Mouse {
 
     #[inline]
     pub(crate) fn process_events(&mut self, evt: &Event, delta: f32) {
+        self.wheel_delta.x = 0.0;
+        self.wheel_delta.y = 0.0;
+
         match evt {
             Event::MouseMove { x, y } => {
                 self.x = *x as f32;
@@ -147,6 +153,10 @@ impl Mouse {
                     self.down.insert(*button, 0.0);
                     self.pressed.insert(*button);
                 }
+            }
+            Event::MouseWheel { delta_x, delta_y } => {
+                self.wheel_delta.x = *delta_x;
+                self.wheel_delta.y = *delta_y;
             }
             _ => {}
         }

--- a/crates/notan_web/src/mouse.rs
+++ b/crates/notan_web/src/mouse.rs
@@ -1,5 +1,6 @@
 use crate::utils::{
-    canvas_add_event_listener, canvas_position_from_global, window_add_event_listener,
+    canvas_add_event_listener, canvas_position_from_global, document_add_event_listener,
+    window_add_event_listener,
 };
 use crate::window::WebWindowBackend;
 use notan_core::events::Event;
@@ -7,7 +8,7 @@ use notan_core::mouse::MouseButton;
 use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
-use web_sys::{MouseEvent, WheelEvent};
+use web_sys::{HtmlCanvasElement, MouseEvent, WheelEvent};
 
 #[derive(Default)]
 pub struct MouseCallbacks {
@@ -17,6 +18,7 @@ pub struct MouseCallbacks {
     on_left_window: Option<Closure<dyn FnMut(MouseEvent)>>,
     on_enter_window: Option<Closure<dyn FnMut(MouseEvent)>>,
     on_wheel: Option<Closure<dyn FnMut(WheelEvent)>>,
+    on_pointer_lock_change: Option<Closure<dyn FnMut(web_sys::Event)>>,
 }
 
 fn mouse_button_to_nae(btn: i16) -> MouseButton {
@@ -40,22 +42,37 @@ pub fn enable_mouse(
     let add_evt_over = win.add_event_fn();
     let add_evt_wheel = win.add_event_fn();
 
+    let last_x_ref = Rc::new(RefCell::new(0));
+    let last_y_ref = Rc::new(RefCell::new(0));
+
     let callbacks = &mut win.mouse_callbacks;
     let canvas = win.canvas.clone();
 
+    let captured = win.captured.clone();
+    let last_x = last_x_ref.clone();
+    let last_y = last_y_ref.clone();
     callbacks.on_move = Some(canvas_add_event_listener(
         &win.canvas,
         "mousemove",
         move |e: MouseEvent| {
             e.stop_propagation();
             e.prevent_default();
-            let (x, y) = canvas_position_from_global(&canvas, e);
+            let (x, y) = get_x_y(
+                &canvas,
+                e,
+                *captured.borrow(),
+                &mut last_x.borrow_mut(),
+                &mut last_y.borrow_mut(),
+            );
             add_evt_move(Event::MouseMove { x, y });
         },
     )?);
 
     let canvas = win.canvas.clone();
     let fullscreen = fullscreen_dispatcher.clone();
+    let captured = win.captured.clone();
+    let last_x = last_x_ref.clone();
+    let last_y = last_y_ref.clone();
     callbacks.on_down = Some(canvas_add_event_listener(
         &win.canvas,
         "mousedown",
@@ -64,13 +81,22 @@ pub fn enable_mouse(
             e.stop_propagation();
             e.prevent_default();
             let button = mouse_button_to_nae(e.button());
-            let (x, y) = canvas_position_from_global(&canvas, e);
+            let (x, y) = get_x_y(
+                &canvas,
+                e,
+                *captured.borrow(),
+                &mut last_x.borrow_mut(),
+                &mut last_y.borrow_mut(),
+            );
             add_evt_down(Event::MouseDown { button, x, y });
         },
     )?);
 
     let canvas = win.canvas.clone();
     let fullscreen = fullscreen_dispatcher.clone();
+    let captured = win.captured.clone();
+    let last_x = last_x_ref.clone();
+    let last_y = last_y_ref.clone();
     callbacks.on_up = Some(window_add_event_listener(
         "mouseup",
         move |e: MouseEvent| {
@@ -78,18 +104,22 @@ pub fn enable_mouse(
             e.stop_propagation();
             e.prevent_default();
             let button = mouse_button_to_nae(e.button());
-            let (x, y) = canvas_position_from_global(&canvas, e);
+            let (x, y) = get_x_y(
+                &canvas,
+                e,
+                *captured.borrow(),
+                &mut last_x.borrow_mut(),
+                &mut last_y.borrow_mut(),
+            );
             add_evt_up(Event::MouseUp { button, x, y });
         },
     )?);
 
     let canvas = win.canvas.clone();
-    let fullscreen = fullscreen_dispatcher.clone();
     callbacks.on_left_window = Some(canvas_add_event_listener(
         &win.canvas,
         "mouseout",
         move |e: MouseEvent| {
-            (*fullscreen.borrow())();
             e.stop_propagation();
             e.prevent_default();
             let (x, y) = canvas_position_from_global(&canvas, e);
@@ -98,12 +128,10 @@ pub fn enable_mouse(
     )?);
 
     let canvas = win.canvas.clone();
-    let fullscreen = fullscreen_dispatcher.clone();
     callbacks.on_enter_window = Some(canvas_add_event_listener(
         &win.canvas,
         "mouseover",
         move |e: MouseEvent| {
-            (*fullscreen.borrow())();
             e.stop_propagation();
             e.prevent_default();
             let (x, y) = canvas_position_from_global(&canvas, e);
@@ -123,5 +151,37 @@ pub fn enable_mouse(
         },
     )?);
 
+    let captured = win.captured.clone();
+    let doc = win.document.clone();
+    let canvas = win.canvas.clone();
+    callbacks.on_pointer_lock_change = Some(document_add_event_listener(
+        "pointerlockchange",
+        move |_| match doc.pointer_lock_element() {
+            Some(el) => {
+                *captured.borrow_mut() = el.id() == canvas.id();
+            }
+            _ => {
+                *captured.borrow_mut() = false;
+            }
+        },
+    )?);
+
     Ok(())
+}
+
+fn get_x_y(
+    canvas: &HtmlCanvasElement,
+    e: MouseEvent,
+    captured: bool,
+    last_x: &mut i32,
+    last_y: &mut i32,
+) -> (i32, i32) {
+    let (x, y) = if captured {
+        (*last_x + e.movement_x(), *last_y + e.movement_y())
+    } else {
+        canvas_position_from_global(&canvas, e)
+    };
+    *last_x = x;
+    *last_y = y;
+    (x, y)
 }

--- a/crates/notan_web/src/touch.rs
+++ b/crates/notan_web/src/touch.rs
@@ -82,7 +82,6 @@ pub fn enable_touch(
         "pointercancel",
         move |e: PointerEvent| {
             if e.pointer_type() == "touch" {
-                (*fullscreen.borrow())();
                 e.stop_propagation();
                 e.prevent_default();
                 let id = e.pointer_id() as _;

--- a/crates/notan_web/src/window.rs
+++ b/crates/notan_web/src/window.rs
@@ -285,6 +285,14 @@ impl WindowBackend for WebWindowBackend {
     fn cursor(&self) -> CursorIcon {
         self.cursor
     }
+
+    fn set_capture_mouse(&mut self, capture: bool) {
+        todo!()
+    }
+
+    fn capture_mouse(&self) -> bool {
+        todo!()
+    }
 }
 
 unsafe impl Send for WebWindowBackend {}

--- a/crates/notan_web/src/window.rs
+++ b/crates/notan_web/src/window.rs
@@ -54,6 +54,9 @@ pub struct WebWindowBackend {
     pub(crate) frame_requested: Rc<RefCell<bool>>,
 
     cursor: CursorIcon,
+
+    capture_requested: Rc<RefCell<Option<bool>>>,
+    pub(crate) captured: Rc<RefCell<bool>>,
 }
 
 impl WebWindowBackend {
@@ -82,6 +85,7 @@ impl WebWindowBackend {
         let fullscreen_requested = Rc::new(RefCell::new(None));
         let fullscreen_last_size = Rc::new(RefCell::new(None));
         let fullscreen_callback_ref = None;
+        let capture_requested = Rc::new(RefCell::new(None));
 
         let min_size = config.min_size;
         let max_size = config.max_size;
@@ -131,6 +135,8 @@ impl WebWindowBackend {
             frame_requested,
 
             cursor: CursorIcon::Default,
+            capture_requested,
+            captured: Rc::new(RefCell::new(false)),
         };
 
         win.init()
@@ -287,11 +293,11 @@ impl WindowBackend for WebWindowBackend {
     }
 
     fn set_capture_mouse(&mut self, capture: bool) {
-        todo!()
+        *self.capture_requested.borrow_mut() = Some(capture);
     }
 
     fn capture_mouse(&self) -> bool {
-        todo!()
+        *self.captured.borrow()
     }
 }
 
@@ -331,6 +337,9 @@ fn fullscreen_dispatcher_callback(win: &mut WebWindowBackend) -> Rc<RefCell<dyn 
     let canvas = win.canvas.clone();
     let doc = win.document.clone();
     let last_size = win.fullscreen_last_size.clone();
+
+    let captured_request = win.capture_requested.clone();
+
     Rc::new(RefCell::new(move || {
         if let Some(full) = fullscreen_requested.borrow_mut().take() {
             if full {
@@ -342,6 +351,14 @@ fn fullscreen_dispatcher_callback(win: &mut WebWindowBackend) -> Rc<RefCell<dyn 
                 }
             } else {
                 doc.exit_fullscreen();
+            }
+        }
+
+        if let Some(capture) = captured_request.borrow_mut().take() {
+            if capture {
+                canvas.request_pointer_lock();
+            } else {
+                doc.exit_pointer_lock();
             }
         }
     }))

--- a/crates/notan_web/src/window.rs
+++ b/crates/notan_web/src/window.rs
@@ -292,11 +292,11 @@ impl WindowBackend for WebWindowBackend {
         self.cursor
     }
 
-    fn set_capture_mouse(&mut self, capture: bool) {
+    fn set_capture_cursor(&mut self, capture: bool) {
         *self.capture_requested.borrow_mut() = Some(capture);
     }
 
-    fn capture_mouse(&self) -> bool {
+    fn capture_cursor(&self) -> bool {
         *self.captured.borrow()
     }
 }

--- a/crates/notan_winit/src/window.rs
+++ b/crates/notan_winit/src/window.rs
@@ -79,13 +79,23 @@ impl WindowBackend for WinitWindowBackend {
         self.cursor
     }
 
-    fn set_capture_mouse(&mut self, capture: bool) {
-        self.captured = capture;
-        log::warn!("Not implemented yet. Awaiting for Winit 0.27");
-        // TODO
+    fn set_capture_cursor(&mut self, capture: bool) {
+        if capture == self.captured {
+            return;
+        }
+
+        let is_macos = cfg!(target_os = "macos");
+        if is_macos {
+            log::warn!("Capture cursor is not implemented yet on MacOS. Awaiting for Winit 0.27");
+            return;
+        }
+
+        if self.window().set_cursor_grab(capture).is_ok() {
+            self.captured = capture;
+        }
     }
 
-    fn capture_mouse(&self) -> bool {
+    fn capture_cursor(&self) -> bool {
         self.captured
     }
 }

--- a/crates/notan_winit/src/window.rs
+++ b/crates/notan_winit/src/window.rs
@@ -11,7 +11,7 @@ pub struct WinitWindowBackend {
     pub(crate) scale_factor: f64,
     pub(crate) lazy: bool,
     cursor: CursorIcon,
-    // win: WindowedContext<PossiblyCurrent>,
+    captured: bool,
 }
 
 impl WindowBackend for WinitWindowBackend {
@@ -78,6 +78,16 @@ impl WindowBackend for WinitWindowBackend {
     fn cursor(&self) -> CursorIcon {
         self.cursor
     }
+
+    fn set_capture_mouse(&mut self, capture: bool) {
+        self.captured = capture;
+        log::warn!("Not implemented yet. Awaiting for Winit 0.27");
+        // TODO
+    }
+
+    fn capture_mouse(&self) -> bool {
+        self.captured
+    }
 }
 
 impl WinitWindowBackend {
@@ -127,6 +137,7 @@ impl WinitWindowBackend {
             scale_factor,
             lazy: config.lazy_loop,
             cursor: CursorIcon::Default,
+            captured: false,
         })
     }
 


### PR DESCRIPTION
* added `Window::set_capture_cursor` and `Window::capture_cursor` to confine the cursor into the window's app
* Added `app.mouse.wheel_delta` to read the delta without check the event loop