### PR TITLE
Added ' texture_to_file' feature to save as png textures or render textures 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,6 +1661,7 @@ dependencies = [
  "log",
  "notan_macro",
  "notan_math",
+ "notan_utils",
  "parking_lot 0.12.0",
 ]
 
@@ -1738,6 +1739,10 @@ name = "notan_utils"
 version = "0.4.2"
 dependencies = [
  "instant",
+ "js-sys",
+ "mime_guess",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ audio = ["notan_audio", "notan_app/audio", "notan_backend?/audio"]
 links = ["notan_app/links", "notan_backend?/links", "notan_egui?/links"]
 drop_files = ["notan_app/drop_files", "notan_backend?/drop_files", "notan_egui?/drop_files"]
 clipboard = ["notan_app/clipboard", "notan_backend?/clipboard", "notan_egui?/clipboard"]
+save_file = ["notan_utils/save_file"]
+texture_to_file = ["notan_graphics/texture_to_file"]
 
 [dev-dependencies]
 egui_demo_lib = "0.18.0"

--- a/crates/notan_graphics/Cargo.toml
+++ b/crates/notan_graphics/Cargo.toml
@@ -18,3 +18,7 @@ parking_lot = "0.12"
 image = { version = "0.24", default-features = false, features = ["jpeg", "png"] }
 notan_math = { path = "../notan_math", version = "0.4.2" }
 notan_macro = { path = "../notan_macro", version = "0.4.2" }
+notan_utils = { path = "../notan_utils", version = "0.4.2" }
+
+[features]
+texture_to_file = ["notan_utils/save_file"]

--- a/crates/notan_graphics/src/buffer.rs
+++ b/crates/notan_graphics/src/buffer.rs
@@ -22,6 +22,9 @@ pub struct Buffer {
     _id_ref: Arc<BufferIdRef>,
     pub usage: BufferUsage,
     pub draw: Option<DrawType>,
+
+    #[cfg(debug_assertions)]
+    pub(crate) initialized: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl Buffer {
@@ -38,12 +41,28 @@ impl Buffer {
             _id_ref: id_ref,
             usage,
             draw,
+
+            #[cfg(debug_assertions)]
+            initialized: Arc::new(Default::default()),
         }
     }
 
     #[inline(always)]
     pub fn id(&self) -> u64 {
         self.id
+    }
+
+    #[cfg(debug_assertions)]
+    #[inline]
+    pub(crate) fn initialize(&self) {
+        self.initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[cfg(debug_assertions)]
+    #[inline]
+    pub(crate) fn is_initialized(&self) -> bool {
+        self.initialized.load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 

--- a/crates/notan_graphics/src/device.rs
+++ b/crates/notan_graphics/src/device.rs
@@ -358,6 +358,20 @@ impl Device {
         bytes: &mut [u8],
         opts: &TextureRead,
     ) -> Result<(), String> {
+        // Check if the buffer size is enough to read the pixels
+        if cfg!(debug_assertions) {
+            let size = (texture.width() * texture.height()) as usize;
+            let bbp = texture.format().bytes_per_pixel() as usize;
+            let len = size * bbp;
+            debug_assert_eq!(
+                len,
+                bytes.len(),
+                "To read the pixels the texture {} needs at a buffer of {} len",
+                texture.id(),
+                len
+            );
+        }
+
         self.backend.read_pixels(texture.id(), bytes, opts)
     }
 

--- a/crates/notan_graphics/src/device.rs
+++ b/crates/notan_graphics/src/device.rs
@@ -373,6 +373,11 @@ impl Device {
 
     #[inline]
     pub fn set_buffer_data<T: BufferDataType>(&mut self, buffer: &Buffer, data: &[T]) {
+        #[cfg(debug_assertions)]
+        if !buffer.is_initialized() {
+            buffer.initialize();
+        }
+
         self.backend
             .set_buffer_data(buffer.id(), bytemuck::cast_slice(data));
     }

--- a/crates/notan_graphics/src/lib.rs
+++ b/crates/notan_graphics/src/lib.rs
@@ -11,6 +11,9 @@ pub mod texture;
 
 pub mod prelude;
 
+#[cfg(feature = "texture_to_file")]
+mod to_file;
+
 pub use device::*;
 pub use limits::*;
 pub use render_texture::*;

--- a/crates/notan_graphics/src/render_texture.rs
+++ b/crates/notan_graphics/src/render_texture.rs
@@ -1,5 +1,6 @@
 use crate::texture::*;
 use crate::{Device, DropManager, Renderer, ResourceId};
+use image::ColorType;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -54,6 +55,15 @@ impl RenderTexture {
 
     pub fn create_renderer(&mut self) -> Renderer {
         Renderer::new(self.width() as _, self.height() as _)
+    }
+
+    #[cfg(feature = "texture_to_file")]
+    pub fn to_file<P: AsRef<std::path::Path>>(
+        &self,
+        gfx: &mut Device,
+        path: P,
+    ) -> Result<(), String> {
+        crate::to_file::save_to_png_file(gfx, self.texture(), true, path)
     }
 }
 

--- a/crates/notan_graphics/src/renderer.rs
+++ b/crates/notan_graphics/src/renderer.rs
@@ -84,12 +84,19 @@ impl Renderer {
     }
 
     pub fn bind_buffer(&mut self, buffer: &Buffer) {
+        #[cfg(debug_assertions)]
+        debug_assert!(
+            buffer.is_initialized(),
+            "Binding buffer {:?} id({}) without data can cause undefined behavior.",
+            buffer.usage,
+            buffer.id()
+        );
+
         self.commands.push(Commands::BindBuffer { id: buffer.id() });
     }
 
     pub fn bind_buffers(&mut self, buffers: &[&Buffer]) {
-        self.commands
-            .extend(buffers.iter().map(|b| Commands::BindBuffer { id: b.id() }));
+        buffers.iter().for_each(|b| self.bind_buffer(b));
     }
 
     pub fn draw(&mut self, offset: i32, count: i32) {

--- a/crates/notan_graphics/src/texture.rs
+++ b/crates/notan_graphics/src/texture.rs
@@ -59,9 +59,16 @@ impl Default for TextureInfo {
 }
 
 impl TextureInfo {
+    #[inline]
+    pub fn bytes_per_pixel(&self) -> u8 {
+        self.format.bytes_per_pixel()
+    }
+}
+
+impl TextureFormat {
     pub fn bytes_per_pixel(&self) -> u8 {
         use TextureFormat::*;
-        match self.format {
+        match self {
             R8 | SRgba8 => 1,
             _ => 4,
         }
@@ -191,6 +198,15 @@ impl Texture {
 
     pub fn base_size(&self) -> (f32, f32) {
         (self.width as _, self.height as _)
+    }
+
+    #[cfg(feature = "texture_to_file")]
+    pub fn to_file<P: AsRef<std::path::Path>>(
+        &self,
+        gfx: &mut Device,
+        path: P,
+    ) -> Result<(), String> {
+        crate::to_file::save_to_png_file(gfx, self, false, path)
     }
 }
 

--- a/crates/notan_graphics/src/to_file.rs
+++ b/crates/notan_graphics/src/to_file.rs
@@ -1,0 +1,45 @@
+#![cfg(feature = "texture_to_file")]
+use crate::Device;
+use crate::Texture;
+use image::ColorType;
+use notan_utils::save_file;
+
+pub(crate) fn save_to_png_file<P: AsRef<std::path::Path>>(
+    gfx: &mut Device,
+    texture: &Texture,
+    inverse: bool,
+    path: P,
+) -> Result<(), String> {
+    use image::ImageEncoder;
+
+    let bpp = texture.format().bytes_per_pixel() as usize;
+    let width = texture.width() as usize;
+    let height = texture.height() as usize;
+    let len = width * height * bpp;
+
+    let mut bytes = vec![0; len];
+    gfx.read_pixels(texture)
+        // frame
+        .read_to(&mut bytes)?;
+
+    if inverse {
+        bytes = bytes.chunks(width * bpp).rev().flatten().cloned().collect();
+    }
+
+    let mut p = path.as_ref().clone();
+    p.with_extension(".png");
+
+    let typ = match bpp {
+        4 => ColorType::Rgba8,
+        1 => ColorType::L8,
+        _ => return Err("Invalid type format".to_string()),
+    };
+
+    let mut data = vec![];
+    let encoder = image::codecs::png::PngEncoder::new(&mut data);
+    encoder
+        .write_image(&bytes, width as _, height as _, typ)
+        .map_err(|e| e.to_string())?;
+
+    save_file(p, &data)
+}

--- a/crates/notan_graphics/src/to_file.rs
+++ b/crates/notan_graphics/src/to_file.rs
@@ -18,9 +18,7 @@ pub(crate) fn save_to_png_file<P: AsRef<std::path::Path>>(
     let len = width * height * bpp;
 
     let mut bytes = vec![0; len];
-    gfx.read_pixels(texture)
-        // frame
-        .read_to(&mut bytes)?;
+    gfx.read_pixels(texture).read_to(&mut bytes)?;
 
     if inverse {
         bytes = bytes.chunks(width * bpp).rev().flatten().cloned().collect();

--- a/crates/notan_utils/Cargo.toml
+++ b/crates/notan_utils/Cargo.toml
@@ -13,3 +13,12 @@ description = "Provides a simple set of utils Notan"
 
 [dependencies]
 instant = { version = "0.1", features = ["wasm-bindgen"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = { version = "0.2.80", optional = true }
+js-sys = { version = "0.3", optional = true }
+web-sys = { version = "0.3", optional = true }
+mime_guess = { version = "2.0", optional = true }
+
+[features]
+save_file = ["mime_guess", "wasm-bindgen", "js-sys", "web-sys", "web-sys?/Window", "web-sys?/Blob", "web-sys?/BlobPropertyBag", "web-sys?/Url", "web-sys?/Element", "web-sys?/HtmlAnchorElement"]

--- a/crates/notan_utils/src/lib.rs
+++ b/crates/notan_utils/src/lib.rs
@@ -1,3 +1,7 @@
-pub use instant::{Duration, Instant};
+#[cfg(feature = "save_file")]
+mod save_file;
 
-// TODO move rand here
+#[cfg(feature = "save_file")]
+pub use save_file::*;
+
+pub use instant::{Duration, Instant};

--- a/crates/notan_utils/src/save_file.rs
+++ b/crates/notan_utils/src/save_file.rs
@@ -1,0 +1,58 @@
+#![cfg(feature = "save_file")]
+
+use std::path::Path;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn save_file<P: AsRef<Path>>(path: P, bytes: &[u8]) -> Result<(), String> {
+    use std::io::Write;
+
+    let mut f = std::fs::File::create(path).map_err(|e| e.to_string())?;
+
+    f.write_all(bytes).map_err(|e| e.to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn save_file<P: AsRef<Path>>(path: P, bytes: &[u8]) -> Result<(), String> {
+    use js_sys::{Array, Uint8Array};
+    use wasm_bindgen::JsCast;
+    use web_sys::Url;
+
+    let mime = mime_guess::from_path(&path)
+        .first_raw()
+        .unwrap_or("")
+        .to_string();
+
+    let mut u8_buff = Uint8Array::new_with_length(bytes.len() as _);
+    u8_buff.copy_from(&bytes);
+
+    let mut array = Array::new();
+    array.push(&u8_buff.buffer());
+
+    let blob = web_sys::Blob::new_with_u8_array_sequence_and_options(
+        &array,
+        &web_sys::BlobPropertyBag::new().type_(&mime),
+    )
+    .map_err(|_| format!("Cannot create a blob from file"))?;
+
+    let url = web_sys::Url::create_object_url_with_blob(&blob)
+        .map_err(|_| format!("Cannot create a blob from file"))?;
+
+    let mut a = web_sys::window()
+        .unwrap()
+        .document()
+        .unwrap()
+        .create_element("a")
+        .unwrap()
+        .dyn_into::<web_sys::HtmlAnchorElement>()
+        .unwrap();
+
+    let p = path.as_ref();
+
+    a.set_href(&url);
+    a.set_download(p.file_name().unwrap().to_str().unwrap());
+    a.click();
+
+    Url::revoke_object_url(&url);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds `Texture::to_file` and `RenderTexture::to_file` to export as png the content of the textures. 
It also adds some debug checks to warn the user when do something silly with Graphics that it can cause undefined behavior. 