### PR TITLE
Enable always on top for window

### DIFF
--- a/crates/notan_app/src/backend.rs
+++ b/crates/notan_app/src/backend.rs
@@ -123,6 +123,12 @@ pub trait WindowBackend {
     /// Returns true if the window is in fullscreen mode
     fn is_fullscreen(&self) -> bool;
 
+    /// Set window to be drawn above others or not
+    fn set_always_on_top(&mut self, enabled: bool);
+
+    /// Returns true if window is drawn above others
+    fn is_always_on_top(&self) -> bool;
+
     /// Window's width
     fn width(&self) -> i32 {
         self.size().0

--- a/crates/notan_app/src/config.rs
+++ b/crates/notan_app/src/config.rs
@@ -51,6 +51,9 @@ pub struct WindowConfig {
     /// Background as transparent
     pub transparent: bool,
 
+    /// Window will be drawn above others
+    pub always_on_top: bool,
+
     /// Enable decorations
     /// `Web: Does nothing`
     pub decorations: bool,
@@ -78,6 +81,7 @@ impl Default for WindowConfig {
             high_dpi: false,
             lazy_loop: false,
             transparent: false,
+            always_on_top: false,
             decorations: true,
             visible: true,
             canvas_id: String::from("notan_canvas"),
@@ -161,6 +165,12 @@ impl WindowConfig {
     /// Set the background as transparent
     pub fn transparent(mut self, transparent: bool) -> Self {
         self.transparent = transparent;
+        self
+    }
+
+    /// Set the background as transparent
+    pub fn always_on_top(mut self, always_on_top: bool) -> Self {
+        self.always_on_top = always_on_top;
         self
     }
 

--- a/crates/notan_app/src/empty.rs
+++ b/crates/notan_app/src/empty.rs
@@ -17,6 +17,7 @@ use notan_audio::AudioBackend;
 pub struct EmptyWindowBackend {
     size: (i32, i32),
     is_fullscreen: bool,
+    is_always_on_top: bool,
     lazy: bool,
     caputed: bool,
     visible: bool,
@@ -37,6 +38,14 @@ impl WindowBackend for EmptyWindowBackend {
 
     fn is_fullscreen(&self) -> bool {
         self.is_fullscreen
+    }
+
+    fn set_always_on_top(&mut self, enabled: bool) {
+        self.is_always_on_top = enabled;
+    }
+
+    fn is_always_on_top(&self) -> bool {
+        self.is_always_on_top
     }
 
     fn dpi(&self) -> f64 {

--- a/crates/notan_web/src/window.rs
+++ b/crates/notan_web/src/window.rs
@@ -315,6 +315,14 @@ impl WindowBackend for WebWindowBackend {
     fn visible(&self) -> bool {
         self.visible
     }
+
+    // No operation, as unsupported in browser
+    fn set_always_on_top(&mut self, enabled: bool) {}
+
+    // Unsupported in browser, always false
+    fn is_always_on_top(&self) -> bool {
+        false
+    }
 }
 
 unsafe impl Send for WebWindowBackend {}

--- a/crates/notan_winit/src/window.rs
+++ b/crates/notan_winit/src/window.rs
@@ -14,6 +14,7 @@ pub struct WinitWindowBackend {
     captured: bool,
     visible: bool,
     high_dpi: bool,
+    is_always_on_top: bool
 }
 
 impl WindowBackend for WinitWindowBackend {
@@ -26,6 +27,15 @@ impl WindowBackend for WinitWindowBackend {
         let inner = self.window().inner_size();
         let logical = inner.to_logical::<f64>(self.scale_factor);
         (logical.width as _, logical.height as _)
+    }
+
+    fn set_always_on_top(&mut self, enabled: bool) {
+        self.window().set_always_on_top(enabled);
+        self.is_always_on_top = enabled;
+    }
+
+    fn is_always_on_top(&self) -> bool {
+        self.is_always_on_top
     }
 
     fn set_fullscreen(&mut self, enabled: bool) {
@@ -131,6 +141,7 @@ impl WinitWindowBackend {
             .with_maximized(config.maximized)
             .with_resizable(config.resizable)
             .with_transparent(config.transparent)
+            .with_always_on_top(config.always_on_top)
             .with_visible(config.visible)
             .with_decorations(config.decorations);
 
@@ -176,6 +187,7 @@ impl WinitWindowBackend {
             captured: false,
             visible: config.visible,
             high_dpi: config.high_dpi,
+            is_always_on_top: false,
         })
     }
 


### PR DESCRIPTION
This PR enables a window to be always on top.
This feature is both present at window creation and can be toggled while running (similar to fullscreen)