### PR TITLE
[egui] accept cmd key on web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Fix audio bug that starts a sound with maximum volume and then fade
 - Added `WindowConfig::always_on_top` and `WindowBackend::set_always_on_top/is_always_on_top` to force the window to the foreground. Has no effect on the web.
 - Added `notan_random` and feature `random` to allow users to disable the default random features and use their own.
+- In EguiPlugin, handle `CMD` key on web
 
 ## v0.6.0 - 27/08/2022
 

--- a/crates/notan_egui/src/plugin.rs
+++ b/crates/notan_egui/src/plugin.rs
@@ -117,15 +117,23 @@ impl Plugin for EguiPlugin {
     ) -> Result<AppFlow, String> {
         let command_modifier = if cfg!(target_arch = "macos") {
             app.keyboard.logo()
+        } else if cfg!(target_arch = "wasm32") {
+            app.keyboard.ctrl() || app.keyboard.logo()
         } else {
             app.keyboard.ctrl()
+        };
+
+        let mac_cmd = if cfg!(target_os = "macos") || cfg!(target_arch = "wasm32") {
+            app.keyboard.logo()
+        } else {
+            false
         };
 
         let modifiers = egui::Modifiers {
             alt: app.keyboard.alt(),
             ctrl: app.keyboard.ctrl(),
             shift: app.keyboard.shift(),
-            mac_cmd: cfg!(target_os = "macos") && app.keyboard.logo(),
+            mac_cmd,
             command: command_modifier,
         };
 


### PR DESCRIPTION
Hey!
currently, command key is ignored on mac when targeting web
to fix we can set `mac_cmd` and `command` similar to how [eframe does it](https://github.com/emilk/egui/blob/master/crates/eframe/src/web/input.rs#L204-L210)