### PR TITLE
expose add_inner_texture in GlowBackend

### DIFF
--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -354,7 +354,7 @@ impl GlowBackend {
         }
     }
 
-    fn add_inner_texture(&mut self, tex: TextureKey, info: &TextureInfo) -> Result<u64, String> {
+    pub fn add_inner_texture(&mut self, tex: TextureKey, info: &TextureInfo) -> Result<u64, String> {
         let inner_texture = InnerTexture::new(tex, info)?;
         self.texture_count += 1;
         self.textures.insert(self.texture_count, inner_texture);


### PR DESCRIPTION
needed for creating custom TextureSources -> https://github.com/Nazariglez/notan/blob/develop/crates/notan_glow/src/html_image.rs#L32

another option, in case we don't wanna expose, is for each backend to `pub TextureKey` which then can become the return type of `TextureSource>create`, and `add_inner_texture` or equivalent is handled by backends