### PR TITLE
Mouse passthrough option

### DIFF
--- a/crates/notan_app/src/config.rs
+++ b/crates/notan_app/src/config.rs
@@ -61,6 +61,9 @@ pub struct WindowConfig {
     /// Hide the windows
     pub visible: bool,
 
+    // Whether mouse events will pass through the window, useful for overlays
+    pub mouse_passthrough: bool,
+
     /// Use or create the canvas with this id. Only Web.
     pub canvas_id: String,
 }
@@ -84,6 +87,7 @@ impl Default for WindowConfig {
             always_on_top: false,
             decorations: true,
             visible: true,
+            mouse_passthrough: false,
             canvas_id: String::from("notan_canvas"),
         }
     }
@@ -183,6 +187,12 @@ impl WindowConfig {
     /// Hide or show the window
     pub fn visible(mut self, visible: bool) -> Self {
         self.visible = visible;
+        self
+    }
+
+    /// Mouse events pass through window
+    pub fn mouse_passthrough(mut self, mouse_passthrough: bool) -> Self {
+        self.mouse_passthrough = mouse_passthrough;
         self
     }
 

--- a/crates/notan_winit/src/window.rs
+++ b/crates/notan_winit/src/window.rs
@@ -173,6 +173,10 @@ impl WinitWindowBackend {
 
         let gl_ctx = unsafe { windowed_context.make_current().unwrap() };
 
+        if config.mouse_passthrough {
+            gl_ctx.window().set_cursor_hittest(false).unwrap();
+        }
+
         let monitor = gl_ctx.window().current_monitor();
         let scale_factor = monitor.as_ref().map_or(1.0, |m| m.scale_factor());
         if config.fullscreen {


### PR DESCRIPTION
Just adding an option so mouse events will passthrough the window.
This is useful if you want to create an overlay using transparent, always on top, and mouse_passthrough window options.
It uses a feature of Winit to achieve this.