### PR TITLE
v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-- 
+
+- Added support for clipboard events using `egui` behind the feature `clipboard`.
+- Exposed `GlowBackend::add_inner_texture` to allow more flexibility extending the backend.
+- Example `input_keyboard` uses not `delta time`.
+- Added `WindowConfig::mouse_passtrhough` to allow mouse events to pass through the window.
 
 ## v0.7.0 - 29/09/2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Exposed `GlowBackend::add_inner_texture` to allow more flexibility extending the backend.
 - Example `input_keyboard` uses not `delta time`.
 - Added `WindowConfig::mouse_passtrhough` to allow mouse events to pass through the window.
+- Fix a minor bug in the `egui` plugin recognizing the `CMD` key on `osx`.
 
 ## v0.7.0 - 29/09/2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## UNRELEASED
+
+-
+
+## v0.7.1 - 08/10/2022
 
 - Added support for clipboard events using `egui` behind the feature `clipboard`.
 - Exposed `GlowBackend::add_inner_texture` to allow more flexibility extending the backend.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fdf5e01086b6be750428ba4a40619f847eb2e95756eee84b18e06e5f0b50342"
+dependencies = [
+ "lazy-bytes-cast",
+ "winapi",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +356,20 @@ checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
 dependencies = [
  "log",
  "web-sys",
+]
+
+[[package]]
+name = "copypasta"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7216b5c1e9ad3867252505995b02d01c6fa7e6db0d8abd42634352ef377777e"
+dependencies = [
+ "clipboard-win",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "smithay-clipboard",
+ "x11-clipboard",
 ]
 
 [[package]]
@@ -1257,6 +1281,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "lazy-bytes-cast"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10257499f089cd156ad82d0a9cd57d9501fa2c989068992a97eb3c27836f206b"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1713,7 @@ name = "notan_egui"
 version = "0.7.0"
 dependencies = [
  "bytemuck",
+ "copypasta",
  "egui",
  "log",
  "notan_app",
@@ -1995,6 +2026,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
+]
+
+[[package]]
 name = "oboe"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,6 +2211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2460,6 +2520,16 @@ dependencies = [
  "wayland-client",
  "wayland-cursor",
  "wayland-protocols",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a345c870a1fae0b1b779085e81b51e614767c239e93503588e54c5b17f4b0e8"
+dependencies = [
+ "smithay-client-toolkit",
+ "wayland-client",
 ]
 
 [[package]]
@@ -3212,6 +3282,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11-clipboard"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7468a5768fea473e6c8c0d4b60d6d7001a64acceaac267207ca0281e1337e8"
+dependencies = [
+ "xcb",
+]
+
+[[package]]
 name = "x11-dl"
 version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,6 +3299,17 @@ dependencies = [
  "lazy_static",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "xcb"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b127bf5bfe9dbb39118d6567e3773d4bbc795411a8e1ef7b7e056bccac0011a9"
+dependencies = [
+ "bitflags",
+ "libc",
+ "quick-xml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "notan"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "egui_demo_lib",
  "notan_app",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "notan_app"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bytemuck",
  "downcast-rs",
@@ -1672,14 +1672,14 @@ dependencies = [
 
 [[package]]
 name = "notan_audio"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "notan_backend"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "notan_web",
  "notan_winit",
@@ -1687,14 +1687,14 @@ dependencies = [
 
 [[package]]
 name = "notan_core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "web-sys",
 ]
 
 [[package]]
 name = "notan_draw"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "log",
  "lyon",
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "notan_egui"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bytemuck",
  "copypasta",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "notan_extra"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "notan_app",
  "spin_sleep",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "notan_glow"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bytemuck",
  "glow",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "notan_glyph"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bytemuck",
  "glyph_brush",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "notan_graphics"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bytemuck",
  "glsl-layout",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "notan_input"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "hashbrown",
  "log",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "notan_log"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "console_log",
  "fern",
@@ -1794,7 +1794,7 @@ dependencies = [
 
 [[package]]
 name = "notan_macro"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "glsl-to-spirv",
  "num",
@@ -1806,14 +1806,14 @@ dependencies = [
 
 [[package]]
 name = "notan_math"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "glam",
 ]
 
 [[package]]
 name = "notan_oddio"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cpal",
  "hashbrown",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "notan_random"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "getrandom",
  "rand",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "notan_text"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "log",
  "notan_app",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "notan_utils"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "instant",
  "js-sys",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "notan_web"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "console_error_panic_hook",
  "futures-util",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "notan_winit"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "glutin",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 categories = ["graphics", "rendering", "wasm", "gui", "multimedia"]
@@ -19,22 +19,22 @@ all-features = true
 lto = true
 
 [dependencies]
-notan_core = { path = "crates/notan_core", version = "0.7.0" }
-notan_input = { path = "crates/notan_input", version = "0.7.0" }
-notan_app = { path = "crates/notan_app", version = "0.7.0" }
-notan_macro = { path = "crates/notan_macro", version = "0.7.0" }
-notan_math = { path = "crates/notan_math", version = "0.7.0" }
-notan_graphics = { path = "crates/notan_graphics", version = "0.7.0" }
-notan_utils = { path = "crates/notan_utils", version = "0.7.0" }
-notan_log = { path = "crates/notan_log", version = "0.7.0", optional = true }
-notan_glyph = { path = "crates/notan_glyph", version = "0.7.0", optional = true }
-notan_draw = { path = "crates/notan_draw", version = "0.7.0", optional = true }
-notan_backend = { path = "crates/notan_backend", version = "0.7.0", optional = true }
-notan_egui = { path = "crates/notan_egui", version = "0.7.0", optional = true }
-notan_text = { path = "crates/notan_text", version = "0.7.0", optional = true }
-notan_audio = { path = "crates/notan_audio", version = "0.7.0", optional = true }
-notan_extra = { path = "crates/notan_extra", version = "0.7.0", optional = true }
-notan_random = { path = "crates/notan_random", version = "0.7.0", optional = true }
+notan_core = { path = "crates/notan_core", version = "0.7.1" }
+notan_input = { path = "crates/notan_input", version = "0.7.1" }
+notan_app = { path = "crates/notan_app", version = "0.7.1" }
+notan_macro = { path = "crates/notan_macro", version = "0.7.1" }
+notan_math = { path = "crates/notan_math", version = "0.7.1" }
+notan_graphics = { path = "crates/notan_graphics", version = "0.7.1" }
+notan_utils = { path = "crates/notan_utils", version = "0.7.1" }
+notan_log = { path = "crates/notan_log", version = "0.7.1", optional = true }
+notan_glyph = { path = "crates/notan_glyph", version = "0.7.1", optional = true }
+notan_draw = { path = "crates/notan_draw", version = "0.7.1", optional = true }
+notan_backend = { path = "crates/notan_backend", version = "0.7.1", optional = true }
+notan_egui = { path = "crates/notan_egui", version = "0.7.1", optional = true }
+notan_text = { path = "crates/notan_text", version = "0.7.1", optional = true }
+notan_audio = { path = "crates/notan_audio", version = "0.7.1", optional = true }
+notan_extra = { path = "crates/notan_extra", version = "0.7.1", optional = true }
+notan_random = { path = "crates/notan_random", version = "0.7.1", optional = true }
 
 [workspace]
 members = ["crates/*"]

--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ On a Macbook (2.3Hz i9 - 16GB RAM):
 - Chrome: 78000 Bunnies at 60FPS
 
 On a high-end Desktop with Archlinux:
-- Native: 144000 Bunnies at 60FPS
-- Chrome: 122000 Bunnies at 60FPS
+- Native: 205000 Bunnies at 60FPS
+- Chrome: 131000 Bunnies at 60FPS
 
 Let's keep in mind that the conditions for `bunnymark` are very unlikely to see in a real project.
 However, it's widely used to test the performance in 2D Draw APIs.

--- a/crates/notan_app/Cargo.toml
+++ b/crates/notan_app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_app"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"
@@ -14,13 +14,13 @@ description = "Provides the core API for Notan"
 [dependencies]
 log = "0.4.17"
 hashbrown = "0.12.3"
-notan_core = { path = "../notan_core", version = "0.7.0" }
-notan_input = { path = "../notan_input", version = "0.7.0" }
-notan_math = { path = "../notan_math", version = "0.7.0" }
-notan_macro = { path = "../notan_macro", version = "0.7.0" }
-notan_graphics = { path = "../notan_graphics", version = "0.7.0" }
-notan_utils = { path = "../notan_utils", version = "0.7.0" }
-notan_audio = { path = "../notan_audio", version = "0.7.0", optional = true }
+notan_core = { path = "../notan_core", version = "0.7.1" }
+notan_input = { path = "../notan_input", version = "0.7.1" }
+notan_math = { path = "../notan_math", version = "0.7.1" }
+notan_macro = { path = "../notan_macro", version = "0.7.1" }
+notan_graphics = { path = "../notan_graphics", version = "0.7.1" }
+notan_utils = { path = "../notan_utils", version = "0.7.1" }
+notan_audio = { path = "../notan_audio", version = "0.7.1", optional = true }
 downcast-rs = "1.2.0"
 indexmap = "1.9.1"
 futures = "0.3.23"

--- a/crates/notan_app/src/config.rs
+++ b/crates/notan_app/src/config.rs
@@ -61,6 +61,9 @@ pub struct WindowConfig {
     /// Hide the windows
     pub visible: bool,
 
+    // Whether mouse events will pass through the window, useful for overlays
+    pub mouse_passthrough: bool,
+
     /// Use or create the canvas with this id. Only Web.
     pub canvas_id: String,
 }
@@ -84,6 +87,7 @@ impl Default for WindowConfig {
             always_on_top: false,
             decorations: true,
             visible: true,
+            mouse_passthrough: false,
             canvas_id: String::from("notan_canvas"),
         }
     }
@@ -183,6 +187,12 @@ impl WindowConfig {
     /// Hide or show the window
     pub fn visible(mut self, visible: bool) -> Self {
         self.visible = visible;
+        self
+    }
+
+    /// Mouse events pass through window
+    pub fn mouse_passthrough(mut self, mouse_passthrough: bool) -> Self {
+        self.mouse_passthrough = mouse_passthrough;
         self
     }
 

--- a/crates/notan_audio/Cargo.toml
+++ b/crates/notan_audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_audio"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"

--- a/crates/notan_backend/Cargo.toml
+++ b/crates/notan_backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_backend"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"
@@ -12,10 +12,10 @@ description = "Provides a default backend for Notan"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-notan_web = { path = "../notan_web", version = "0.7.0" }
+notan_web = { path = "../notan_web", version = "0.7.1" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-notan_winit = { path = "../notan_winit", version = "0.7.0" }
+notan_winit = { path = "../notan_winit", version = "0.7.1" }
 
 [features]
 audio = ["notan_web/audio", "notan_winit/audio"]

--- a/crates/notan_core/Cargo.toml
+++ b/crates/notan_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_core"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"

--- a/crates/notan_draw/Cargo.toml
+++ b/crates/notan_draw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_draw"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"
@@ -13,12 +13,12 @@ description = "Provides a simple 2D API for Notan"
 
 [dependencies]
 log = "0.4.17"
-notan_app = { path = "../notan_app", version = "0.7.0" }
-notan_graphics = { path = "../notan_graphics", version = "0.7.0" }
-notan_macro = { path = "../notan_macro", version = "0.7.0" }
-notan_math = { path = "../notan_math", version = "0.7.0" }
-notan_glyph = { path = "../notan_glyph", version = "0.7.0" }
-notan_text = { path = "../notan_text", version = "0.7.0" }
+notan_app = { path = "../notan_app", version = "0.7.1" }
+notan_graphics = { path = "../notan_graphics", version = "0.7.1" }
+notan_macro = { path = "../notan_macro", version = "0.7.1" }
+notan_math = { path = "../notan_math", version = "0.7.1" }
+notan_glyph = { path = "../notan_glyph", version = "0.7.1" }
+notan_text = { path = "../notan_text", version = "0.7.1" }
 lyon = "1.0.0"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"

--- a/crates/notan_egui/Cargo.toml
+++ b/crates/notan_egui/Cargo.toml
@@ -19,7 +19,12 @@ notan_core = { path = "../notan_core", version = "0.7.0" }
 notan_app = { path = "../notan_app", version = "0.7.0" }
 notan_macro = { path = "../notan_macro", version = "0.7.0" }
 
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies.copypasta]
+version = "0.8.1"
+default-features = false
+
 [features]
 links = []
-clipboard = []
+clipboard = ["notan_app/clipboard" , "copypasta/x11"]
+clipboard-wayland = ["copypasta/wayland", "clipboard"]
 drop_files = []

--- a/crates/notan_egui/Cargo.toml
+++ b/crates/notan_egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_egui"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"
@@ -15,9 +15,9 @@ description = "Provides EGUI support for Notan"
 log = "0.4.17"
 egui = { version = "0.18.1", features = ["bytemuck"] }
 bytemuck = "1.10.0"
-notan_core = { path = "../notan_core", version = "0.7.0" }
-notan_app = { path = "../notan_app", version = "0.7.0" }
-notan_macro = { path = "../notan_macro", version = "0.7.0" }
+notan_core = { path = "../notan_core", version = "0.7.1" }
+notan_app = { path = "../notan_app", version = "0.7.1" }
+notan_macro = { path = "../notan_macro", version = "0.7.1" }
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.copypasta]
 version = "0.8.1"

--- a/crates/notan_egui/src/plugin.rs
+++ b/crates/notan_egui/src/plugin.rs
@@ -164,7 +164,7 @@ impl Plugin for EguiPlugin {
         _assets: &mut Assets,
         event: &Event,
     ) -> Result<AppFlow, String> {
-        let command_modifier = if cfg!(target_arch = "macos") {
+        let command_modifier = if cfg!(target_os = "macos") {
             app.keyboard.logo()
         } else if cfg!(target_arch = "wasm32") {
             app.keyboard.ctrl() || app.keyboard.logo()

--- a/crates/notan_egui/src/plugin.rs
+++ b/crates/notan_egui/src/plugin.rs
@@ -6,21 +6,62 @@ use notan_app::{
     App, AppFlow, ClearOptions, Color, CursorIcon as NCursorIcon, Device, Event, ExtContainer,
     GfxExtension, GfxRenderer, Graphics, Plugin, Plugins, RenderTexture,
 };
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "clipboard")]
+use notan_core::keyboard::KeyCode;
+
 use std::cell::RefCell;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "clipboard")]
+use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "links")]
 use egui::output::OpenUrl;
 
-#[derive(Default)]
 pub struct EguiPlugin {
     ctx: egui::Context,
+    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "clipboard")]
+    clipboard: Arc<Mutex<Clipboard>>,
     raw_input: egui::RawInput,
     platform_output: Option<egui::PlatformOutput>,
     latest_evt_was_touch: bool,
     needs_repaint: bool,
 }
 
+impl Default for EguiPlugin {
+    fn default() -> Self {
+        Self {
+            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(feature = "clipboard")]
+            clipboard: Arc::new(Mutex::new(Clipboard::default())),
+            ctx: Default::default(),
+            raw_input: Default::default(),
+            platform_output: Default::default(),
+            latest_evt_was_touch: Default::default(),
+            needs_repaint: Default::default(),
+        }
+    }
+}
+
 impl EguiPlugin {
+    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "clipboard")]
+    fn set_clipboard(&mut self, new_text: &mut String) {
+        if !new_text.is_empty() {
+            // Compare
+            let mut clipboard = self.clipboard.lock().unwrap();
+            if let Some(text) = clipboard.get() {
+                if text != *new_text {
+                    clipboard.set(new_text.clone());
+                    // Clear here to avoid memory leaks since not needed any longer.
+                    new_text.clear();
+                }
+            }
+        }
+    }
+
     #[inline]
     pub(crate) fn add_event(&mut self, evt: egui::Event) {
         self.raw_input.events.push(evt);
@@ -41,6 +82,14 @@ impl EguiPlugin {
         if !self.needs_repaint {
             self.needs_repaint = needs_repaint;
         }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "clipboard")]
+        // To avoid unused_mut if not using clipboard
+        let mut platform_output = platform_output;
+        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "clipboard")]
+        self.set_clipboard(&mut platform_output.copied_text);
 
         self.platform_output = Some(platform_output);
 
@@ -189,6 +238,34 @@ impl Plugin for EguiPlugin {
             Event::MouseEnter { .. } => {}
             Event::MouseLeft { .. } => self.add_event(egui::Event::PointerGone),
             Event::KeyDown { key } => {
+                #[cfg(not(target_arch = "wasm32"))]
+                #[cfg(feature = "clipboard")]
+                {
+                    if *key == KeyCode::C && (modifiers.ctrl || modifiers.command) {
+                        self.add_event(egui::Event::Copy);
+                    } else if *key == KeyCode::X && (modifiers.ctrl || modifiers.command) {
+                        self.add_event(egui::Event::Cut);
+                    } else if *key == KeyCode::V && (modifiers.ctrl || modifiers.command) {
+                        // Use let binding, otherwise rustc complains.
+                        let binding = || {
+                            let clipboard = &*self.clipboard;
+                            clipboard.lock().unwrap().get()
+                        };
+                        if let Some(text) = binding() {
+                            self.add_event(egui::Event::Paste(text));
+                        }
+                    } else {
+                        if let Some(key) = to_egui_key(key) {
+                            self.add_event(egui::Event::Key {
+                                key,
+                                pressed: true,
+                                modifiers,
+                            })
+                        }
+                    }
+                }
+
+                #[cfg(not(feature = "clipboard"))]
                 if let Some(key) = to_egui_key(key) {
                     self.add_event(egui::Event::Key {
                         key,
@@ -197,6 +274,7 @@ impl Plugin for EguiPlugin {
                     })
                 }
             }
+
             Event::KeyUp { key } => {
                 if let Some(key) = to_egui_key(key) {
                     self.add_event(egui::Event::Key {
@@ -213,11 +291,17 @@ impl Plugin for EguiPlugin {
             }
 
             #[cfg(feature = "clipboard")]
-            Event::Copy => self.add_event(egui::Event::Copy),
+            Event::Copy => {
+                // self.add_event(egui::Event::Copy),
+            }
             #[cfg(feature = "clipboard")]
-            Event::Cut => self.add_event(egui::Event::Cut),
+            Event::Cut => {
+                // self.add_event(egui::Event::Cut),
+            }
             #[cfg(feature = "clipboard")]
-            Event::Paste(text) => self.add_event(egui::Event::Paste(text.clone())),
+            Event::Paste(_text) => {
+                // self.add_event(egui::Event::Paste(_text.into()))
+            }
 
             #[cfg(feature = "drop_files")]
             Event::DragEnter { path, mime, .. } => {
@@ -396,5 +480,61 @@ impl EguiPluginSugar for Plugins {
     fn egui(&mut self, run_ui: impl FnOnce(&Context)) -> Output {
         let mut ext = self.get_mut::<EguiPlugin>().unwrap();
         ext.run(run_ui)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "clipboard")]
+pub struct Clipboard {
+    clipboard: Option<copypasta::ClipboardContext>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "clipboard")]
+impl Default for Clipboard {
+    fn default() -> Self {
+        Self {
+            clipboard: init_copypasta(),
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "clipboard")]
+impl Clipboard {
+    pub fn get(&mut self) -> Option<String> {
+        if let Some(clipboard) = &mut self.clipboard {
+            use copypasta::ClipboardProvider as _;
+            match clipboard.get_contents() {
+                Ok(contents) => Some(contents),
+                Err(err) => {
+                    eprintln!("Paste error: {}", err);
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    }
+
+    pub fn set(&mut self, text: String) {
+        if let Some(clipboard) = &mut self.clipboard {
+            use copypasta::ClipboardProvider as _;
+            if let Err(err) = clipboard.set_contents(text) {
+                eprintln!("Copy/Cut error: {}", err);
+            }
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "clipboard")]
+fn init_copypasta() -> Option<copypasta::ClipboardContext> {
+    match copypasta::ClipboardContext::new() {
+        Ok(clipboard) => Some(clipboard),
+        Err(err) => {
+            eprintln!("Failed to initialize clipboard: {}", err);
+            None
+        }
     }
 }

--- a/crates/notan_extra/Cargo.toml
+++ b/crates/notan_extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_extra"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"
@@ -12,7 +12,7 @@ description = "Provides extra features or plugins for Notan"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-notan_app = { path = "../notan_app", version = "0.7.0" }
+notan_app = { path = "../notan_app", version = "0.7.1" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 spin_sleep = "1.1.1"

--- a/crates/notan_glow/Cargo.toml
+++ b/crates/notan_glow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_glow"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"
@@ -15,7 +15,7 @@ description = "Provides support for OpenGL, OpenGL ES and WebGL for Notan"
 log = "0.4.17"
 bytemuck = "1.12.1"
 glow = "0.11.2"
-notan_graphics = { path= "../notan_graphics", version = "0.7.0" }
+notan_graphics = { path= "../notan_graphics", version = "0.7.1" }
 hashbrown = "0.12.3"
 image = { version = "0.24.3", default-features = false, features = ["jpeg", "png"] }
 

--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -354,7 +354,7 @@ impl GlowBackend {
         }
     }
 
-    fn add_inner_texture(&mut self, tex: TextureKey, info: &TextureInfo) -> Result<u64, String> {
+    pub fn add_inner_texture(&mut self, tex: TextureKey, info: &TextureInfo) -> Result<u64, String> {
         let inner_texture = InnerTexture::new(tex, info)?;
         self.texture_count += 1;
         self.textures.insert(self.texture_count, inner_texture);

--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -354,7 +354,11 @@ impl GlowBackend {
         }
     }
 
-    pub fn add_inner_texture(&mut self, tex: TextureKey, info: &TextureInfo) -> Result<u64, String> {
+    pub fn add_inner_texture(
+        &mut self,
+        tex: TextureKey,
+        info: &TextureInfo,
+    ) -> Result<u64, String> {
         let inner_texture = InnerTexture::new(tex, info)?;
         self.texture_count += 1;
         self.textures.insert(self.texture_count, inner_texture);

--- a/crates/notan_glow/src/to_glow.rs
+++ b/crates/notan_glow/src/to_glow.rs
@@ -107,7 +107,8 @@ impl ToGlow for VertexFormat {
         use VertexFormat::*;
         match &self {
             UInt8 | UInt8x2 | UInt8x3 | UInt8x4 => glow::UNSIGNED_BYTE,
-            _ => glow::FLOAT,
+            UInt8Norm | UInt8x2Norm | UInt8x3Norm | UInt8x4Norm => glow::UNSIGNED_BYTE,
+            Float32 | Float32x2 | Float32x3 | Float32x4 => glow::FLOAT,
         }
     }
 }

--- a/crates/notan_glyph/Cargo.toml
+++ b/crates/notan_glyph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_glyph"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/Nazariglez/notan"
@@ -14,6 +14,6 @@ description = "Provides glyph's support for Notan"
 log = "0.4.17"
 glyph_brush = "0.7.5"
 bytemuck = "1.12.1"
-notan_app = { path = "../notan_app", version = "0.7.0" }
-notan_graphics = { path = "../notan_graphics", version = "0.7.0" }
-notan_math = { path = "../notan_math", version = "0.7.0" }
+notan_app = { path = "../notan_app", version = "0.7.1" }
+notan_graphics = { path = "../notan_graphics", version = "0.7.1" }
+notan_math = { path = "../notan_math", version = "0.7.1" }

--- a/crates/notan_graphics/Cargo.toml
+++ b/crates/notan_graphics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_graphics"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"
@@ -15,9 +15,9 @@ description = "Provides simple graphics API for Notan"
 bytemuck = "1.12.1"
 parking_lot = "0.12.1"
 image = { version = "0.24.3", default-features = false, features = ["jpeg", "png"] }
-notan_math = { path = "../notan_math", version = "0.7.0" }
-notan_macro = { path = "../notan_macro", version = "0.7.0" }
-notan_utils = { path = "../notan_utils", version = "0.7.0" }
+notan_math = { path = "../notan_math", version = "0.7.1" }
+notan_macro = { path = "../notan_macro", version = "0.7.1" }
+notan_utils = { path = "../notan_utils", version = "0.7.1" }
 glsl-layout = { version = "0.4.2", features = ["glam"] }
 
 [features]

--- a/crates/notan_input/Cargo.toml
+++ b/crates/notan_input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_input"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 description = "Provides a set of API to manage user's input"
 
 [dependencies]
-notan_core = { path = "../notan_core", version = "0.7.0" }
-notan_math = { path = "../notan_math", version = "0.7.0" }
+notan_core = { path = "../notan_core", version = "0.7.1" }
+notan_math = { path = "../notan_math", version = "0.7.1" }
 hashbrown = "0.12.3"
 log = "0.4.17"

--- a/crates/notan_log/Cargo.toml
+++ b/crates/notan_log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_log"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"
@@ -14,7 +14,7 @@ description = "Provides a multipatform log support for Notan"
 [dependencies]
 log = "0.4.17"
 fern = { version = "0.6.1", features = ["colored"] }
-notan_app = { path = "../notan_app", version = "0.7.0" }
+notan_app = { path = "../notan_app", version = "0.7.1" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 time = { version = "0.3.14", features = ["formatting", "local-offset"] }

--- a/crates/notan_macro/Cargo.toml
+++ b/crates/notan_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_macro"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"

--- a/crates/notan_math/Cargo.toml
+++ b/crates/notan_math/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_math"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"

--- a/crates/notan_oddio/Cargo.toml
+++ b/crates/notan_oddio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_oddio"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/Nazariglez/notan"
@@ -11,7 +11,7 @@ description = "Provides support for Audio features using Oddio"
 [dependencies]
 log = "0.4.17"
 hashbrown = "0.12.3"
-notan_audio = { path = "../notan_audio", version = "0.7.0" }
+notan_audio = { path = "../notan_audio", version = "0.7.1" }
 cpal = { version = "0.14.0", features = ["wasm-bindgen"] }
 oddio = "0.6.2"
 symphonia = { version = "0.5.1", features = ["mp3"] }

--- a/crates/notan_oddio/src/decoder.rs
+++ b/crates/notan_oddio/src/decoder.rs
@@ -60,9 +60,7 @@ fn get_samples(
                     continue;
                 }
 
-                if let Err(e) = decode_packet(&mut samples, decoder, packet) {
-                    return Err(e);
-                }
+                decode_packet(&mut samples, decoder, packet)?;
             }
             Err(err) => {
                 if let IoError(err) = err {

--- a/crates/notan_random/Cargo.toml
+++ b/crates/notan_random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_random"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"

--- a/crates/notan_text/Cargo.toml
+++ b/crates/notan_text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_text"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/Nazariglez/notan"
@@ -11,8 +11,8 @@ description = "Provides a simple Text API for Notan"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-notan_app = { path = "../notan_app", version = "0.7.0" }
-notan_graphics = { path = "../notan_graphics", version = "0.7.0" }
-notan_glyph = { path = "../notan_glyph", version = "0.7.0" }
-notan_math = { path = "../notan_math", version = "0.7.0" }
+notan_app = { path = "../notan_app", version = "0.7.1" }
+notan_graphics = { path = "../notan_graphics", version = "0.7.1" }
+notan_glyph = { path = "../notan_glyph", version = "0.7.1" }
+notan_math = { path = "../notan_math", version = "0.7.1" }
 log = "0.4.17"

--- a/crates/notan_utils/Cargo.toml
+++ b/crates/notan_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_utils"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"

--- a/crates/notan_web/Cargo.toml
+++ b/crates/notan_web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_web"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"
@@ -13,17 +13,17 @@ description = "Provides a web/wasm32 backend for Notan"
 
 [dependencies]
 log = "0.4.17"
-notan_core = { path = "../notan_core", version = "0.7.0" }
-notan_app = { path = "../notan_app", version = "0.7.0" }
+notan_core = { path = "../notan_core", version = "0.7.1" }
+notan_app = { path = "../notan_app", version = "0.7.1" }
 wasm-bindgen = "0.2.82"
 js-sys = "0.3.59"
 wasm-bindgen-futures = "0.4.32"
 console_error_panic_hook = "0.1.7"
-notan_glow = { path = "../notan_glow", version = "0.7.0" }
-notan_graphics = { path = "../notan_graphics", version = "0.7.0" }
+notan_glow = { path = "../notan_glow", version = "0.7.1" }
+notan_graphics = { path = "../notan_graphics", version = "0.7.1" }
 futures-util = "0.3.23"
-notan_audio = { path = "../notan_audio", version = "0.7.0", optional = true }
-notan_oddio = { path = "../notan_oddio", version = "0.7.0", optional = true }
+notan_audio = { path = "../notan_audio", version = "0.7.1", optional = true }
+notan_oddio = { path = "../notan_oddio", version = "0.7.1", optional = true }
 
 [dependencies.web-sys]
 version = "0.3.59"

--- a/crates/notan_web/src/utils.rs
+++ b/crates/notan_web/src/utils.rs
@@ -188,6 +188,15 @@ pub fn canvas_visible(canvas: &HtmlCanvasElement, visible: bool) {
     }
 }
 
+pub fn canvas_mouse_passthrough(canvas: &HtmlCanvasElement, passthrough: bool) {
+    if let Err(e) = canvas
+        .style()
+        .set_property("pointer-events", if passthrough { "none" } else { "auto" })
+    {
+        log::error!("{:?}", e);
+    }
+}
+
 pub fn get_notan_size(canvas: &HtmlCanvasElement) -> (i32, i32) {
     let width = canvas
         .get_attribute("notan-width")

--- a/crates/notan_web/src/window.rs
+++ b/crates/notan_web/src/window.rs
@@ -2,8 +2,8 @@ use crate::keyboard::{enable_keyboard, KeyboardCallbacks};
 use crate::mouse::{enable_mouse, MouseCallbacks};
 use crate::touch::{enable_touch, PointerCallbacks};
 use crate::utils::{
-    canvas_add_event_listener, canvas_visible, get_notan_size, get_or_create_canvas,
-    request_animation_frame, set_size_dpi, window_add_event_listener,
+    canvas_add_event_listener, canvas_mouse_passthrough, canvas_visible, get_notan_size,
+    get_or_create_canvas, request_animation_frame, set_size_dpi, window_add_event_listener,
 };
 use notan_app::{CursorIcon, WindowConfig};
 use notan_app::{Event, EventIterator, WindowBackend};
@@ -76,6 +76,7 @@ impl WebWindowBackend {
 
         let visible = config.visible;
         canvas_visible(&canvas, visible);
+        canvas_mouse_passthrough(&canvas, config.mouse_passthrough);
 
         let canvas_parent = canvas
             .parent_element()

--- a/crates/notan_winit/Cargo.toml
+++ b/crates/notan_winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_winit"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nazarí González <nazari.nz@gmail.com>"]
 edition = "2021"
 readme = "README.md"
@@ -13,11 +13,11 @@ description = "Provides a native backend using winit for Notan"
 
 [dependencies]
 log = "0.4.17"
-notan_core = { path = "../notan_core", version = "0.7.0" }
-notan_app = { path = "../notan_app", version = "0.7.0" }
-notan_glow = { path = "../notan_glow", version = "0.7.0" }
-notan_audio = { path = "../notan_audio", version = "0.7.0", optional = true }
-notan_oddio = { path = "../notan_oddio", version = "0.7.0", optional = true }
+notan_core = { path = "../notan_core", version = "0.7.1" }
+notan_app = { path = "../notan_app", version = "0.7.1" }
+notan_glow = { path = "../notan_glow", version = "0.7.1" }
+notan_audio = { path = "../notan_audio", version = "0.7.1", optional = true }
+notan_oddio = { path = "../notan_oddio", version = "0.7.1", optional = true }
 glutin = "0.29.1"
 webbrowser = { version = "0.7.1", optional = true }
 mime_guess = { version = "2.0.4", optional = true }

--- a/crates/notan_winit/src/window.rs
+++ b/crates/notan_winit/src/window.rs
@@ -173,6 +173,10 @@ impl WinitWindowBackend {
 
         let gl_ctx = unsafe { windowed_context.make_current().unwrap() };
 
+        if config.mouse_passthrough {
+            gl_ctx.window().set_cursor_hittest(false).unwrap();
+        }
+
         let monitor = gl_ctx.window().current_monitor();
         let scale_factor = monitor.as_ref().map_or(1.0, |m| m.scale_factor());
         if config.fullscreen {

--- a/examples/input_keyboard.rs
+++ b/examples/input_keyboard.rs
@@ -1,6 +1,8 @@
 use notan::draw::*;
 use notan::prelude::*;
 
+const MOVE_SPEED:f32 = 100.0;
+
 #[derive(AppState)]
 struct State {
     font: Font,
@@ -34,21 +36,20 @@ fn setup(gfx: &mut Graphics) -> State {
 fn update(app: &mut App, state: &mut State) {
     state.last_key = app.keyboard.last_key_released();
 
-    // TODO use delta
     if app.keyboard.is_down(KeyCode::W) {
-        state.y -= 2.0;
+        state.y -= MOVE_SPEED * app.timer.delta_f32();
     }
 
     if app.keyboard.is_down(KeyCode::A) {
-        state.x -= 2.0;
+        state.x -= MOVE_SPEED * app.timer.delta_f32();
     }
 
     if app.keyboard.is_down(KeyCode::S) {
-        state.y += 2.0;
+        state.y += MOVE_SPEED * app.timer.delta_f32();
     }
 
     if app.keyboard.is_down(KeyCode::D) {
-        state.x += 2.0;
+        state.x += MOVE_SPEED * app.timer.delta_f32();
     }
 }
 

--- a/examples/input_keyboard.rs
+++ b/examples/input_keyboard.rs
@@ -1,7 +1,7 @@
 use notan::draw::*;
 use notan::prelude::*;
 
-const MOVE_SPEED:f32 = 100.0;
+const MOVE_SPEED: f32 = 100.0;
 
 #[derive(AppState)]
 struct State {

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -5,6 +5,7 @@ crates=(
   notan_core
   notan_input
   notan_audio
+  notan_random
   notan_utils
   notan_math
   notan_macro


### PR DESCRIPTION
- Added support for clipboard events using `egui` behind the feature `clipboard`.  #143 
- Exposed `GlowBackend::add_inner_texture` to allow more flexibility extending the backend. #144 
- Example `input_keyboard` uses not `delta time`. #146 
- Added `WindowConfig::mouse_passtrhough` to allow mouse events to pass through the window. #147 
- Fix a minor bug in the `egui` plugin recognizing the `CMD` key on `osx`. 

Thank you so much for all the contributions!