### PR TITLE
Allow clippy::main_recursion lint

### DIFF
--- a/crates/notan_macro/src/lib.rs
+++ b/crates/notan_macro/src/lib.rs
@@ -26,6 +26,7 @@ fn handle_main_func(input: ItemFn) -> TokenStream {
 
         #[no_mangle]
         pub extern fn notan_main() -> #ret {
+            #[allow(clippy::main_recursion)]
             #ident()
         }
     };


### PR DESCRIPTION
This is a small PR to address https://github.com/Nazariglez/notan/issues/159

I did some digging and found that clippy will let you `allow` certain lints and hence silence them from clippy's output. Adding this `allow` macro to main in a given example doesn't seem to work however appending it to the computed output of `#[notan_main]` seems to fix the issue.

 ## Before this change
Running any example/program with notan (e.g. `cargo clippy --example window_open`) would produce...
```sh
warning: recursing into entrypoint `main`
 --> examples/window_open.rs:4:4
  |
4 | fn main() -> Result<(), String> {
  |    ^^^^
  |
  = note: `#[warn(clippy::main_recursion)]` on by default
  = help: consider using another function for this recursion
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#main_recursion

warning: `notan` (example "window_open") generated 1 warning
```

The total warnings produced by `cargo clippy --examples` was 73, with 58 of them being the above "recusing into entrypoint `main`"

## After this change
The same command above produces no warnings. The output of `cargo clippy --examples` is also significantly reduced to just 15 warnings.

> **Total warnings calculated with**: ```cargo clippy --examples 2>&1 >/dev/null | grep 'warning: [^`]' -c```
