### PR TITLE
Mouse passthrough toggle

### DIFF
--- a/crates/notan_app/src/backend.rs
+++ b/crates/notan_app/src/backend.rs
@@ -111,6 +111,9 @@ pub enum CursorIcon {
 
 /// Represents a window
 pub trait WindowBackend {
+    // Returns the window id
+    fn id(&self) -> u64;
+
     /// Sets the window's size
     fn set_size(&mut self, width: i32, height: i32);
 
@@ -174,4 +177,10 @@ pub trait WindowBackend {
 
     /// Returns if the window is visible
     fn visible(&self) -> bool;
+
+    // sets whether you can click through the window
+    fn set_mouse_passthrough(&mut self, pass_through: bool);
+
+    // returns whether you can click through the window
+    fn mouse_passthrough(&mut self) -> bool;
 }

--- a/crates/notan_app/src/empty.rs
+++ b/crates/notan_app/src/empty.rs
@@ -23,9 +23,14 @@ pub struct EmptyWindowBackend {
     lazy: bool,
     captured: bool,
     visible: bool,
+    mouse_passthrough: bool,
 }
 
 impl WindowBackend for EmptyWindowBackend {
+    fn id(&self) -> u64 {
+        0
+    }
+
     fn set_size(&mut self, width: i32, height: i32) {
         self.size = (width, height);
     }
@@ -94,6 +99,14 @@ impl WindowBackend for EmptyWindowBackend {
 
     fn visible(&self) -> bool {
         self.visible
+    }
+
+    fn mouse_passthrough(&mut self) -> bool {
+        self.mouse_passthrough
+    }
+
+    fn set_mouse_passthrough(&mut self, pass_through: bool) {
+        self.mouse_passthrough = pass_through;
     }
 }
 

--- a/crates/notan_web/src/window.rs
+++ b/crates/notan_web/src/window.rs
@@ -231,6 +231,10 @@ impl WebWindowBackend {
 }
 
 impl WindowBackend for WebWindowBackend {
+    fn id(&self) -> u64 {
+        0
+    }
+
     fn set_size(&mut self, width: i32, height: i32) {
         set_size_dpi(&self.canvas, width as _, height as _);
         self.config.width = width;
@@ -330,6 +334,14 @@ impl WindowBackend for WebWindowBackend {
 
     // Unsupported in browser, always false
     fn is_always_on_top(&self) -> bool {
+        false
+    }
+
+    // No operation, as unsupported in browser
+    fn set_mouse_passthrough(&mut self, clickable: bool) {}
+
+    // No operation, as unsupported in browser
+    fn mouse_passthrough(&mut self) -> bool {
         false
     }
 }

--- a/crates/notan_winit/src/window.rs
+++ b/crates/notan_winit/src/window.rs
@@ -15,9 +15,14 @@ pub struct WinitWindowBackend {
     visible: bool,
     high_dpi: bool,
     is_always_on_top: bool,
+    mouse_passthrough: bool,
 }
 
 impl WindowBackend for WinitWindowBackend {
+    fn id(&self) -> u64 {
+        self.window().id().into()
+    }
+
     fn set_size(&mut self, width: i32, height: i32) {
         self.window()
             .set_inner_size(LogicalSize::new(width, height));
@@ -141,6 +146,14 @@ impl WindowBackend for WinitWindowBackend {
     fn visible(&self) -> bool {
         self.visible
     }
+
+    fn mouse_passthrough(&mut self) -> bool {
+        self.mouse_passthrough
+    }
+
+    fn set_mouse_passthrough(&mut self, pass_through: bool) {
+        self.gl_ctx.window().set_cursor_hittest(!pass_through).unwrap();
+    }
 }
 
 impl WinitWindowBackend {
@@ -202,6 +215,7 @@ impl WinitWindowBackend {
             visible: config.visible,
             high_dpi: config.high_dpi,
             is_always_on_top: false,
+            mouse_passthrough: config.mouse_passthrough
         })
     }
 


### PR DESCRIPTION
- A small change so you can toggle mouse passthrough on and off with `app.window().set_mouse_passthrough(bool)`
- Also added the ability to return the window id