### PR TITLE
Fix debug assert in Device::inner_read_pixels

### DIFF
--- a/crates/notan_graphics/src/device.rs
+++ b/crates/notan_graphics/src/device.rs
@@ -418,15 +418,15 @@ impl Device {
     ) -> Result<(), String> {
         // Check if the buffer size is enough to read the pixels
         if cfg!(debug_assertions) {
-            let size = (texture.width() * texture.height()) as usize;
-            let bpp = texture.format().bytes_per_pixel() as usize;
+            let size = (opts.width * opts.height) as usize;
+            let bpp = opts.format.bytes_per_pixel() as usize;
             let len = size * bpp;
-            debug_assert_eq!(
-                len,
+            debug_assert!(
+                bytes.len() >= len,
+                "The provided buffer len of {} is less than the required {} when reading pixels from texture {}",
                 bytes.len(),
-                "To read the pixels the texture {} needs at a buffer of {} len",
-                texture.id(),
-                len
+                len,
+                texture.id()
             );
         }
 


### PR DESCRIPTION
Assert that the provided buffer is at least the size of the bytes to be read, which may be smaller than the texture's buffer size.