### PR TITLE
Minor fixes and improvements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 # UNRELEASED
 - Added `WindowBackend::set_title` and `WindowBackend::title` to change or get the title at any time.
 - Improved stencil clearing when setting a mask on the draw api at the end of the pass.
+- Fix panic using Draw API to draw text with `max_width` and `size` as 0. 
 
 ## v0.9.3 - 12/02/2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+# UNRELEASED
+- Added `WindowBackend::set_title` and `WindowBackend::title` to change or get the title at any time.
+
 ## v0.9.3 - 12/02/2023
 
 - Added `WindowBackend::screen_size` to get the screen's resolution size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 - Added `WindowBackend::set_title` and `WindowBackend::title` to change or get the title at any time.
 - Improved stencil clearing when setting a mask on the draw api at the end of the pass.
 - Fix panic using Draw API to draw text with `max_width` and `size` as 0. 
+- Fix `debug_assert` in `Device::inner_read_pixels`.
+- Added support for `include` directives using `shaderc`.
 
 ## v0.9.3 - 12/02/2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 # UNRELEASED
 - Added `WindowBackend::set_title` and `WindowBackend::title` to change or get the title at any time.
+- Improved stencil clearing when setting a mask on the draw api at the end of the pass.
 
 ## v0.9.3 - 12/02/2023
 

--- a/crates/notan_app/src/backend.rs
+++ b/crates/notan_app/src/backend.rs
@@ -188,6 +188,12 @@ pub trait WindowBackend {
     /// Returns the window's size
     fn size(&self) -> (i32, i32);
 
+    /// Set the window's title
+    fn set_title(&mut self, title: &str);
+
+    /// Returns current windows title
+    fn title(&self) -> &str;
+
     /// Returns if the window is visible
     fn visible(&self) -> bool;
 

--- a/crates/notan_app/src/empty.rs
+++ b/crates/notan_app/src/empty.rs
@@ -16,6 +16,7 @@ use notan_audio::AudioBackend;
 
 #[derive(Default)]
 pub struct EmptyWindowBackend {
+    title: String,
     size: (i32, i32),
     position: (i32, i32),
     is_fullscreen: bool,
@@ -111,6 +112,14 @@ impl WindowBackend for EmptyWindowBackend {
 
     fn visible(&self) -> bool {
         self.visible
+    }
+
+    fn set_title(&mut self, title: &str) {
+        self.title = title.to_string();
+    }
+
+    fn title(&self) -> &str {
+        &self.title
     }
 }
 

--- a/crates/notan_draw/src/draw.rs
+++ b/crates/notan_draw/src/draw.rs
@@ -29,6 +29,7 @@ pub struct Draw {
     pub(crate) masking: bool,
     pub(crate) needs_to_clean_stencil: bool,
     pub(crate) glyphs_calculator: Calculator,
+    mask_batches: Option<Vec<Batch>>,
 }
 
 impl Clone for Draw {
@@ -53,6 +54,7 @@ impl Clone for Draw {
             needs_to_clean_stencil: self.needs_to_clean_stencil,
             text_batch_indices: self.text_batch_indices.clone(),
             glyphs_calculator: Calculator::new(),
+            mask_batches: self.mask_batches.clone(),
         }
     }
 }
@@ -82,6 +84,7 @@ impl Draw {
             needs_to_clean_stencil: false,
             text_batch_indices: None,
             glyphs_calculator: Calculator::new(),
+            mask_batches: None,
         }
     }
 
@@ -90,44 +93,54 @@ impl Draw {
     pub fn matrix(&self) -> &Mat3 {
         self.transform.matrix()
     }
-    //
-    // pub fn round_pixels(&mut self, _round: bool) {
-    //     //TODO round pixels to draw "2d pixel games"
-    //     todo!("round pixels");
-    // }
+
+    fn process_mask_batches(&mut self) {
+        if let Some(mask_batches) = self.mask_batches.take() {
+            //Move the current batch to the queue
+            if let Some(b) = self.current_batch.take() {
+                self.batches.push(b);
+            }
+
+            self.batches.extend(mask_batches.iter().map(|batch| {
+                let mut b = batch.clone();
+                b.is_mask = true;
+                b
+            }));
+        }
+    }
 
     pub fn mask(&mut self, mask: Option<&Self>) {
         debug_assert!(!(self.masking && mask.is_some()), "Already using mask.");
 
         match mask {
-            Some(m) => {
-                self.masking = true;
-                self.needs_to_clean_stencil = true;
+            Some(m) if !self.masking => {
+                let mut mask_batches = m.batches.clone();
+                if let Some(b) = m.current_batch.as_ref() {
+                    mask_batches.push(b.clone());
+                }
+
+                if !mask_batches.is_empty() {
+                    self.masking = true;
+                    self.mask_batches = Some(mask_batches);
+                }
+            }
+            None if self.masking => {
+                self.masking = false;
+                self.mask_batches = None;
 
                 //Move the current batch to the queue
                 if let Some(b) = self.current_batch.take() {
-                    self.batches.push(b);
-                }
-
-                //Reserve the space for the mask batches
-                // let new_capacity = self.batches.len() + m.batches.len() + 1;
-                // self.batches.reserve(new_capacity);
-                self.batches.extend(m.batches.iter().map(|batch| {
-                    let mut b = batch.clone();
-                    b.is_mask = true;
-                    b
-                }));
-
-                if let Some(mut b) = m.current_batch.clone() {
-                    b.is_mask = true;
                     self.batches.push(b);
                 }
             }
             _ => {
-                self.masking = false;
-                //Move the current batch to the queue
-                if let Some(b) = self.current_batch.take() {
-                    self.batches.push(b);
+                #[cfg(debug_assertions)]
+                {
+                    log::warn!(
+                        "Draw setting mask as: {:?} when the value is {:?} is a no-op",
+                        mask.is_some(),
+                        self.masking
+                    );
                 }
             }
         }
@@ -197,6 +210,11 @@ impl Draw {
         F1: Fn(&Batch, &I) -> bool,
         F2: Fn(&I) -> BatchType,
     {
+        if self.masking {
+            self.needs_to_clean_stencil = true;
+            self.process_mask_batches();
+        }
+
         let needs_new_batch = needs_new_batch(self, info, is_diff_type);
         if needs_new_batch {
             if let Some(old) = self.current_batch.take() {

--- a/crates/notan_draw/src/manager.rs
+++ b/crates/notan_draw/src/manager.rs
@@ -96,7 +96,7 @@ fn paint_batch(
         manager.drawing_mask = true;
     } else if !b.is_mask && manager.drawing_mask {
         manager.drawing_mask = false;
-        manager.renderer.begin(Some(&Default::default()));
+        manager.renderer.begin(None);
     }
 
     match &b.typ {

--- a/crates/notan_draw/src/texts/text.rs
+++ b/crates/notan_draw/src/texts/text.rs
@@ -136,12 +136,19 @@ impl DrawProcess for TextSection<'_> {
             flip,
         } = self;
 
+        #[cfg(debug_assertions)]
+        {
+            if size < 1.0 {
+                log::warn!("Text must use a size bigger or equal than 1.0");
+            }
+        }
+
         let color = color.with_alpha(color.a * alpha);
         let count = text.chars().filter(|c| !c.is_whitespace()).count();
 
         let g_text = Text::new(text)
             .with_color(color.rgba())
-            .with_scale(size)
+            .with_scale(size.max(1.0))
             .with_font_id(font);
 
         let mut section = Section::default()

--- a/crates/notan_web/src/window.rs
+++ b/crates/notan_web/src/window.rs
@@ -66,6 +66,8 @@ pub struct WebWindowBackend {
     pub(crate) captured: Rc<RefCell<bool>>,
 
     mouse_passthrough: bool,
+
+    title: String,
 }
 
 impl WebWindowBackend {
@@ -122,6 +124,8 @@ impl WebWindowBackend {
         let lazy = Rc::new(RefCell::new(config.lazy_loop));
         let frame_requested = Rc::new(RefCell::new(false));
 
+        let title = config.title.clone();
+
         let win = Self {
             window,
             document,
@@ -160,6 +164,7 @@ impl WebWindowBackend {
             visible,
 
             mouse_passthrough,
+            title,
         };
 
         win.init()
@@ -381,6 +386,14 @@ impl WindowBackend for WebWindowBackend {
 
     fn visible(&self) -> bool {
         self.visible
+    }
+
+    fn set_title(&mut self, title: &str) {
+        self.title = title.to_string();
+    }
+
+    fn title(&self) -> &str {
+        &self.title
     }
 }
 

--- a/crates/notan_winit/src/window.rs
+++ b/crates/notan_winit/src/window.rs
@@ -18,6 +18,7 @@ pub struct WinitWindowBackend {
     high_dpi: bool,
     is_always_on_top: bool,
     mouse_passthrough: bool,
+    title: String,
 }
 
 impl WindowBackend for WinitWindowBackend {
@@ -167,6 +168,15 @@ impl WindowBackend for WinitWindowBackend {
     fn visible(&self) -> bool {
         self.visible
     }
+
+    fn set_title(&mut self, title: &str) {
+        self.title = title.to_string();
+        self.window().set_title(&self.title);
+    }
+
+    fn title(&self) -> &str {
+        &self.title
+    }
 }
 
 fn load_icon(path: &Option<PathBuf>) -> Option<Icon> {
@@ -239,16 +249,26 @@ impl WinitWindowBackend {
             gl_manager.set_fullscreen(config.fullscreen);
         }
 
+        let WindowConfig {
+            lazy_loop,
+            visible,
+            high_dpi,
+            title,
+            mouse_passthrough,
+            ..
+        } = config;
+
         Ok(Self {
             gl_manager,
             scale_factor,
-            lazy: config.lazy_loop,
+            lazy: lazy_loop,
             cursor: CursorIcon::Default,
             captured: false,
-            visible: config.visible,
-            high_dpi: config.high_dpi,
+            visible,
+            high_dpi,
             is_always_on_top: false,
-            mouse_passthrough: config.mouse_passthrough,
+            mouse_passthrough,
+            title,
         })
     }
 


### PR DESCRIPTION
- Added `WindowBackend::set_title` and `WindowBackend::title` to change or get the title at any time.
- Improved stencil clearing when setting a mask on the draw api at the end of the pass.
- Fix panic using Draw API to draw text with `max_width` and `size` as 0. 


fixes #221 #238 