### PR TITLE
Added ability to set Window/Taskbar icon from raw data

### DIFF
--- a/crates/notan_app/src/config.rs
+++ b/crates/notan_app/src/config.rs
@@ -70,11 +70,17 @@ pub struct WindowConfig {
     /// Use or create the canvas with this id. Only Web.
     pub canvas_id: String,
 
-    /// Window icon file
+    /// Optinal Window icon filepath
     pub window_icon_path: Option<PathBuf>,
 
-    /// Task bar icon file
+    /// Optinal Window icon filedata
+    pub window_icon_data: Option<&'static [u8]>,
+
+    /// Optinal Task bar icon filepath
     pub taskbar_icon_path: Option<PathBuf>,
+
+    /// Optinal Task bar icon filedata
+    pub taskbar_icon_data: Option<&'static [u8]>,
 }
 
 impl Default for WindowConfig {
@@ -99,7 +105,9 @@ impl Default for WindowConfig {
             mouse_passthrough: false,
             canvas_id: String::from("notan_canvas"),
             window_icon_path: None,
+            window_icon_data: None,
             taskbar_icon_path: None,
+            taskbar_icon_data: None,
         }
     }
 }
@@ -219,9 +227,21 @@ impl WindowConfig {
         self
     }
 
+    /// Window icon data
+    pub fn set_window_icon_data(mut self, window_icon_data: Option<&'static [u8]>) -> Self {
+        self.window_icon_data = window_icon_data;
+        self
+    }
+
     /// Task bar icon path
     pub fn set_taskbar_icon(mut self, taskbar_icon_path: Option<PathBuf>) -> Self {
         self.taskbar_icon_path = taskbar_icon_path;
+        self
+    }
+
+    /// Task bar icon data
+    pub fn set_taskbar_icon_data(mut self, taskbar_icon_data: Option<&'static [u8]>) -> Self {
+        self.taskbar_icon_data = taskbar_icon_data;
         self
     }
 }

--- a/crates/notan_winit/src/window.rs
+++ b/crates/notan_winit/src/window.rs
@@ -186,21 +186,41 @@ impl WindowBackend for WinitWindowBackend {
     }
 }
 
-fn load_icon(path: &Option<PathBuf>) -> Option<Icon> {
-    match path {
-        Some(path) => {
-            let (icon_rgba, icon_width, icon_height) = {
-                let image = image::open(path)
-                    .expect("Failed to open icon path")
-                    .into_rgba8();
-                let (width, height) = image.dimensions();
-                let rgba = image.into_raw();
-                (rgba, width, height)
-            };
-            Some(Icon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to open icon"))
+fn load_icon(path: &Option<PathBuf>, data: &Option<&'static [u8]>) -> Option<Icon> {
+    match (path, data) {
+        (Some(path), None) => Some(load_icon_from_path(path)), // Handle Path
+        (None, Some(data)) => Some(load_icon_from_data(data)), // Handle Data
+        (Some(_), Some(data)) => {
+            // Handle User Passing Both
+            log::warn!("Creating Icon from Data. You have set a path and data for your Icon, please choose only one!");
+            Some(load_icon_from_data(data))
         }
-        None => None,
+        (None, None) => None,
     }
+}
+
+fn load_icon_from_path(path: &PathBuf) -> Icon {
+    let (icon_rgba, icon_width, icon_height) = {
+        let image = image::open(path)
+            .expect("Failed to open icon path")
+            .into_rgba8();
+        let (width, height) = image.dimensions();
+        let rgba = image.into_raw();
+        (rgba, width, height)
+    };
+    Icon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to open icon")
+}
+
+fn load_icon_from_data(data: &'static [u8]) -> Icon {
+    let icon_data = image::load_from_memory(data)
+        .expect("Failed to Create Icon from Data")
+        .into_rgba8();
+
+    let icon_width = icon_data.width();
+    let icon_height = icon_data.height();
+    let icon_rgba = icon_data.into_raw();
+
+    Icon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to open icon")
 }
 
 impl WinitWindowBackend {
@@ -219,12 +239,18 @@ impl WinitWindowBackend {
             .with_window_level(level)
             .with_visible(config.visible)
             .with_decorations(config.decorations)
-            .with_window_icon(load_icon(&config.window_icon_path));
+            .with_window_icon(load_icon(
+                &config.window_icon_path,
+                &config.window_icon_data,
+            ));
 
         #[cfg(target_os = "windows")]
         {
             use winit::platform::windows::WindowBuilderExtWindows;
-            builder = builder.with_taskbar_icon(load_icon(&config.taskbar_icon_path));
+            builder = builder.with_taskbar_icon(load_icon(
+                &config.taskbar_icon_path,
+                &config.taskbar_icon_data,
+            ));
         }
 
         #[cfg(target_os = "macos")]

--- a/examples/window_icon_from_raw.rs
+++ b/examples/window_icon_from_raw.rs
@@ -1,0 +1,12 @@
+use notan::prelude::*;
+
+#[notan_main]
+fn main() -> Result<(), String> {
+    // Check the documentation for more options
+    let window_config = WindowConfig::new()
+        .set_title("Window Icon Data Demo")
+        .set_window_icon_data(Some(include_bytes!("./examples/assets/rust.ico")))
+        .set_taskbar_icon_data(Some(include_bytes!("./examples/assets/rust.ico")));
+
+    notan::init().add_config(window_config).build()
+}

--- a/examples/window_icon_from_raw.rs
+++ b/examples/window_icon_from_raw.rs
@@ -5,8 +5,8 @@ fn main() -> Result<(), String> {
     // Check the documentation for more options
     let window_config = WindowConfig::new()
         .set_title("Window Icon Data Demo")
-        .set_window_icon_data(Some(include_bytes!("./examples/assets/rust.ico")))
-        .set_taskbar_icon_data(Some(include_bytes!("./examples/assets/rust.ico")));
+        .set_window_icon_data(Some(include_bytes!("./assets/rust.ico")))
+        .set_taskbar_icon_data(Some(include_bytes!("./assets/rust.ico")));
 
     notan::init().add_config(window_config).build()
 }


### PR DESCRIPTION
This Pull-Request implements the feature requested in #215

Change Log:
- Added set_window_icon_data to WindowConfig
- Added set_taskbar_icon_data to WindowConfig
- Added window_icon_from_raw.rs Example

Example Usage:
```rust
use notan::prelude::*;

#[notan_main]
fn main() -> Result<(), String> {
    // Check the documentation for more options
    let window_config = WindowConfig::new()
        .set_title("Window Icon Data Demo")
        .set_window_icon_data(Some(include_bytes!("./examples/assets/rust.ico")))
        .set_taskbar_icon_data(Some(include_bytes!("./examples/assets/rust.ico")));

    notan::init().add_config(window_config).build()
}
```

(This is my first Pull Request to this crate)