### PR TITLE
add support for passing a window position upon creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## UNRELEASED
-
+- Added `WindowConfig::set_position` to set x/y position before creating the window.
 - Changed `Renderer.begin` uses `Option<ClearOption>` instead of `Option<&ClearOption>`.
 - Changed sizes and positions for Window and Textures from `i32` to `u32`.
 - Added `AppTimer::elapsed` to return time since init as `Duration`.

--- a/crates/notan_app/src/config.rs
+++ b/crates/notan_app/src/config.rs
@@ -27,6 +27,9 @@ pub struct WindowConfig {
     /// Maximum resizable window's size
     pub max_size: Option<(u32, u32)>,
 
+    /// Window's x/y start position
+    pub position: Option<(i32, i32)>,
+
     /// Start the window maximized
     /// `Web: The canvas will fill the size of the parent of the HtmlCanvasElement`
     pub maximized: bool,
@@ -92,6 +95,7 @@ impl Default for WindowConfig {
             fullscreen: false,
             min_size: None,
             max_size: None,
+            position: None,
             maximized: false,
             resizable: false,
             vsync: false,
@@ -152,6 +156,13 @@ impl WindowConfig {
     /// Sets the window's maximum size
     pub fn set_max_size(mut self, width: u32, height: u32) -> Self {
         self.max_size = Some((width, height));
+        self
+    }
+
+    /// Sets the window's x and y
+    pub fn set_position(mut self, x: u32, y: u32) -> Self {
+        self.x = x;
+        self.y = y;
         self
     }
 

--- a/crates/notan_app/src/config.rs
+++ b/crates/notan_app/src/config.rs
@@ -160,9 +160,8 @@ impl WindowConfig {
     }
 
     /// Sets the window's x and y
-    pub fn set_position(mut self, x: u32, y: u32) -> Self {
-        self.x = x;
-        self.y = y;
+    pub fn set_position(mut self, x: i32, y: i32) -> Self {
+        self.position = Some((x, y));
         self
     }
 

--- a/crates/notan_winit/src/window.rs
+++ b/crates/notan_winit/src/window.rs
@@ -280,7 +280,7 @@ impl WinitWindowBackend {
         if let Some((x, y)) = config.position {
             let mut safe_x = x;
             let mut safe_y = y;
-            
+
             // This is already done by the OS in Linux/MacOS
             #[cfg(windows)]
             {
@@ -291,10 +291,7 @@ impl WinitWindowBackend {
                 safe_y = clamped_position.1;
             }
 
-            builder = builder.with_position(LogicalPosition::new(
-                safe_x as f64,
-                safe_y as f64,
-            ));
+            builder = builder.with_position(LogicalPosition::new(safe_x as f64, safe_y as f64));
         }
 
         let gl_manager = GlManager::new(builder, event_loop, &config)?;

--- a/crates/notan_winit/src/window.rs
+++ b/crates/notan_winit/src/window.rs
@@ -278,16 +278,23 @@ impl WinitWindowBackend {
         }
 
         if let Some((x, y)) = config.position {
+            let mut safe_x = x;
+            let mut safe_y = y;
+            
+            // This is already done by the OS in Linux/MacOS
             #[cfg(windows)]
             {
-                // This is already done by the OS in Linux/MacOS
                 let clamped_position =
                     clamp_window_to_sane_position(config.width, config.height, x, y, &event_loop);
-                builder = builder.with_position(LogicalPosition::new(
-                    clamped_position.0 as f64,
-                    clamped_position.1 as f64,
-                ));
+
+                safe_x = clamped_position.0;
+                safe_y = clamped_position.1;
             }
+
+            builder = builder.with_position(LogicalPosition::new(
+                safe_x as f64,
+                safe_y as f64,
+            ));
         }
 
         let gl_manager = GlManager::new(builder, event_loop, &config)?;

--- a/crates/notan_winit/src/window.rs
+++ b/crates/notan_winit/src/window.rs
@@ -276,6 +276,10 @@ impl WinitWindowBackend {
             builder = builder.with_max_inner_size(LogicalSize::new(w, h));
         }
 
+        if let Some((x, y)) = config.position {
+            builder = builder.with_position(LogicalSize::new(x, y));
+        }
+
         let gl_manager = GlManager::new(builder, event_loop, &config)?;
 
         // Try setting vsync.

--- a/crates/notan_winit/src/window.rs
+++ b/crates/notan_winit/src/window.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use crate::gl_manager::GlManager;
 use notan_app::WindowConfig;
 use notan_app::{CursorIcon, WindowBackend};
-use winit::dpi::{LogicalSize, PhysicalPosition};
+use winit::dpi::{LogicalPosition, LogicalSize, PhysicalPosition};
 use winit::event_loop::EventLoop;
 use winit::window::Fullscreen::Borderless;
 use winit::window::{
@@ -277,7 +277,7 @@ impl WinitWindowBackend {
         }
 
         if let Some((x, y)) = config.position {
-            builder = builder.with_position(LogicalSize::new(x, y));
+            builder = builder.with_position(LogicalPosition::new(x as f64, y as f64));
         }
 
         let gl_manager = GlManager::new(builder, event_loop, &config)?;

--- a/examples/renderer_instancing_cubes.rs
+++ b/examples/renderer_instancing_cubes.rs
@@ -143,7 +143,6 @@ fn setup(gfx: &mut Graphics) -> State {
     // Generate 1 color per cube
     let mut rng = Random::default();
     let colors = (0..INSTANCES)
-        .into_iter()
         .flat_map(|_| {
             [
                 rng.gen_range(0.0..1.0),


### PR DESCRIPTION
This allows a window to spawn at the specified position and wont lead to odd "jumping" behavior we see right now after setting the position after window creation.

Clamping logic is from here: https://github.com/Shel-M/egui/blob/master/crates/egui-winit/src/window_settings.rs#LL91C10-L91C10