### PR TITLE
Fix for "extension to create ES context with wgl is not present"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 
 - Added traits `Serialize` and `Deserialize` to `Color` with the feature `serde` enabled.
+- Fixed an error acquiring the GL Context due required samples configuration. 
 
 ## v0.10.0 - 11/09/2023
 

--- a/crates/notan_macro/src/handlers.rs
+++ b/crates/notan_macro/src/handlers.rs
@@ -124,7 +124,7 @@ fn enum_impl_generator(tokens: &Tokens, once: bool) -> String {
         .ret
         .as_ref()
         .map(|v| format!(" -> {v}"))
-        .unwrap_or_else(|| "".to_string());
+        .unwrap_or_default();
     let callback = enum_callback_generics(&combo(&tokens.params), &tokens.params);
 
     let reference = if once { "" } else { "&" };
@@ -171,7 +171,7 @@ fn trait_impl_generator(tokens: &Tokens, gen_type: GenericType, fn_literal: &str
         .ret
         .as_ref()
         .map(|v| format!(" -> {v}"))
-        .unwrap_or_else(|| "".to_string());
+        .unwrap_or_default();
 
     let s_type = match gen_type {
         GenericType::Plugin => "Plugin + 'static",
@@ -252,8 +252,7 @@ fn enum_generics(g: &[Vec<String>], r: Option<&String>, fn_literal: &str) -> Str
                 "_{}(Box<dyn {fn_literal}({}){}>)",
                 i,
                 gen,
-                r.map(|v| format!(" -> {v}"))
-                    .unwrap_or_else(|| "".to_string())
+                r.map(|v| format!(" -> {v}")).unwrap_or_default()
             )
         })
         .collect::<Vec<_>>()

--- a/crates/notan_winit/src/gl_manager.rs
+++ b/crates/notan_winit/src/gl_manager.rs
@@ -205,7 +205,7 @@ struct InnerSupport {
 }
 
 fn check_support(required_samples: u8, needs_transparency: bool, conf: &GConfig) -> InnerSupport {
-    let req_samples = conf.num_samples() == required_samples;
+    let req_samples = conf.num_samples() == required_samples && required_samples != 0;
     let srgb = conf.srgb_capable();
     let supports_transparency = conf.supports_transparency().unwrap_or(false);
     let transparency = if needs_transparency {


### PR DESCRIPTION
So, I came up with this very simple patch for the error: "extension to create ES context with wgl is not present" #289 . I tested it out on three operating systems - my main PC which runs windows 10 and macOS with dual boot. The gotten configurations seem to be correct. Also tested this out on a laptop that runs windows 11, everything also seems to be correct and working.

closes #289 