### PR TITLE
expose notan_draw builder publicly to allow custom builders

### DIFF
--- a/crates/notan_draw/src/lib.rs
+++ b/crates/notan_draw/src/lib.rs
@@ -24,3 +24,4 @@ pub use patterns::*;
 pub use shapes::*;
 pub use texts::*;
 pub use transform::*;
+pub use builder::*;

--- a/crates/notan_draw/src/lib.rs
+++ b/crates/notan_draw/src/lib.rs
@@ -14,6 +14,7 @@ mod transform;
 mod atlas;
 
 pub use atlas::*;
+pub use builder::*;
 pub use config::*;
 pub use custom_pipeline::*;
 pub use draw::*;
@@ -24,4 +25,3 @@ pub use patterns::*;
 pub use shapes::*;
 pub use texts::*;
 pub use transform::*;
-pub use builder::*;


### PR DESCRIPTION
In order to be able to use the `DrawProcess` trait from the `builder` module in the `notan_draw` crate from _user code_.

I've leveraged this patch to implement custom drawing features on the `Draw` instance.