### PR TITLE
make AppTimer public

### DIFF
--- a/crates/notan_app/src/app.rs
+++ b/crates/notan_app/src/app.rs
@@ -1,4 +1,4 @@
-use crate::timer::AppTimer;
+pub use crate::timer::AppTimer;
 use crate::{Backend, WindowBackend};
 
 #[cfg(feature = "audio")]


### PR DESCRIPTION
Right now it is used in many examples, fully documented, but not publicly accesible.