### PR TITLE
Add support for drawing points

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,10 @@ name = "draw_pattern"
 required-features = ["draw"]
 
 [[example]]
+name = "draw_points"
+required-features = ["draw"]
+
+[[example]]
 name = "draw_projection"
 required-features = ["draw"]
 

--- a/crates/notan_draw/src/shapes.rs
+++ b/crates/notan_draw/src/shapes.rs
@@ -4,6 +4,7 @@ mod geometry;
 mod line;
 mod painter;
 mod path;
+mod point;
 mod polygon;
 mod rect;
 mod star;
@@ -18,12 +19,14 @@ pub use line::Line;
 pub use painter::create_shape_pipeline;
 pub(crate) use painter::*;
 pub use path::Path;
+pub use point::{Point, XAlignment, YAlignment};
 pub use polygon::Polygon;
 pub use rect::Rectangle;
 pub use star::Star;
 pub use triangle::Triangle;
 
 pub trait DrawShapes {
+    fn point(&mut self, x: f32, y: f32) -> DrawBuilder<Point>;
     fn line(&mut self, p1: (f32, f32), p2: (f32, f32)) -> DrawBuilder<Line>;
     fn triangle(&mut self, a: (f32, f32), b: (f32, f32), c: (f32, f32)) -> DrawBuilder<Triangle>;
     fn path(&mut self) -> DrawBuilder<Path>;
@@ -35,6 +38,10 @@ pub trait DrawShapes {
 }
 
 impl DrawShapes for Draw {
+    fn point(&mut self, x: f32, y: f32) -> DrawBuilder<Point> {
+        DrawBuilder::new(self, Point::new(x, y))
+    }
+
     fn line(&mut self, p1: (f32, f32), p2: (f32, f32)) -> DrawBuilder<Line> {
         DrawBuilder::new(self, Line::new(p1, p2))
     }

--- a/crates/notan_draw/src/shapes/point.rs
+++ b/crates/notan_draw/src/shapes/point.rs
@@ -1,0 +1,163 @@
+use super::path::Path;
+use crate::builder::DrawProcess;
+use crate::draw::Draw;
+use crate::transform::DrawTransform;
+use notan_graphics::color::Color;
+use notan_math::Mat3;
+
+/// Point alignment in the X axis.
+///
+/// This is only meaningful for width > 1.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum XAlignment {
+    Left,
+    #[default]
+    Center,
+    Right,
+}
+/// Point alignment in the Y axis.
+///
+/// This is only meaningful for width > 1.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum YAlignment {
+    Top,
+    #[default]
+    Center,
+    Bottom,
+}
+
+/// A single point.
+pub struct Point {
+    x: f32,
+    y: f32,
+    color: Color,
+    stroke_width: f32,
+    x_align: XAlignment,
+    y_align: YAlignment,
+    alpha: f32,
+    matrix: Option<Mat3>,
+}
+
+impl Point {
+    pub fn new(x: f32, y: f32) -> Self {
+        Self {
+            x,
+            y,
+            color: Color::WHITE,
+            stroke_width: 1.0,
+            x_align: XAlignment::Center,
+            y_align: YAlignment::Center,
+            alpha: 1.0,
+            matrix: None,
+        }
+    }
+
+    pub fn color(&mut self, color: Color) -> &mut Self {
+        self.color = color;
+        self
+    }
+
+    pub fn width(&mut self, width: f32) -> &mut Self {
+        self.stroke_width = width;
+        self
+    }
+
+    pub fn alpha(&mut self, alpha: f32) -> &mut Self {
+        self.alpha = alpha;
+        self
+    }
+
+    pub fn align(&mut self, x_align: XAlignment, y_align: YAlignment) -> &mut Self {
+        self.x_align = x_align;
+        self.y_align = y_align;
+        self
+    }
+    pub fn x_align(&mut self, x_align: XAlignment) -> &mut Self {
+        self.x_align = x_align;
+        self
+    }
+    pub fn y_align(&mut self, y_align: YAlignment) -> &mut Self {
+        self.y_align = y_align;
+        self
+    }
+    pub fn x_align_left(&mut self) -> &mut Self {
+        self.x_align = XAlignment::Left;
+        self
+    }
+    pub fn x_align_center(&mut self) -> &mut Self {
+        self.x_align = XAlignment::Center;
+        self
+    }
+    pub fn x_align_right(&mut self) -> &mut Self {
+        self.x_align = XAlignment::Right;
+        self
+    }
+    pub fn y_align_top(&mut self) -> &mut Self {
+        self.y_align = YAlignment::Top;
+        self
+    }
+    pub fn y_align_middle(&mut self) -> &mut Self {
+        self.y_align = YAlignment::Center;
+        self
+    }
+    pub fn y_align_bottom(&mut self) -> &mut Self {
+        self.y_align = YAlignment::Bottom;
+        self
+    }
+}
+
+impl DrawTransform for Point {
+    fn matrix(&mut self) -> &mut Option<Mat3> {
+        &mut self.matrix
+    }
+}
+
+impl DrawProcess for Point {
+    fn draw_process(self, draw: &mut Draw) {
+        let Self {
+            x,
+            y,
+            color,
+            stroke_width,
+            x_align,
+            y_align,
+            alpha,
+            matrix,
+        } = self;
+
+        let mut path = Path::new();
+
+        let x_from = match x_align {
+            XAlignment::Left => x + stroke_width / 2.,
+            XAlignment::Center => x + 1.0,
+            XAlignment::Right => x + 1.0 - stroke_width / 2.,
+        };
+        let x_to = match x_align {
+            XAlignment::Left => x + stroke_width / 2.,
+            XAlignment::Center => x + 1.0,
+            XAlignment::Right => x + 1.0 - stroke_width / 2.,
+        };
+        let y_from = match y_align {
+            YAlignment::Top => y,
+            YAlignment::Center => y + 1.0 - stroke_width / 2.,
+            YAlignment::Bottom => y + 1.0 - stroke_width,
+        };
+        let y_to = match y_align {
+            YAlignment::Top => y + stroke_width,
+            YAlignment::Center => y + 1.0 + stroke_width / 2.,
+            YAlignment::Bottom => y + 1.0,
+        };
+
+        path.move_to(x_from, y_from)
+            .line_to(x_to, y_to)
+            .stroke(stroke_width)
+            .color(color.with_alpha(color.a * alpha))
+            .close();
+
+        if let Some(m) = matrix {
+            path.transform(m);
+        }
+
+        path.draw_process(draw);
+    }
+}

--- a/examples/draw_points.rs
+++ b/examples/draw_points.rs
@@ -1,0 +1,108 @@
+use notan::draw::*;
+use notan::prelude::*;
+
+#[derive(AppState)]
+struct State {
+    #[cfg(feature = "notan_text")]
+    font: Font,
+}
+
+#[notan_main]
+fn main() -> Result<(), String> {
+    let win_config = WindowConfig::default().set_size(380, 380);
+    notan::init_with(setup)
+        .add_config(DrawConfig)
+        .add_config(win_config)
+        .draw(draw)
+        .build()
+}
+
+fn setup(gfx: &mut Graphics) -> State {
+    #[cfg(feature = "notan_text")]
+    {
+        let font = gfx
+            .create_font(include_bytes!("./assets/Ubuntu-B.ttf"))
+            .unwrap();
+        State { font }
+    }
+    #[cfg(not(feature = "notan_text"))]
+    State {}
+}
+
+fn draw(gfx: &mut Graphics, state: &mut State) {
+    let mut draw = gfx.create_draw();
+    draw.clear(Color::BLACK);
+
+    let (xpad, ypad) = (20., 20.); // padding
+    let (mut xal, mut yal); // aligment
+
+    for xsquare in 0..=2 {
+        xal = match xsquare {
+            0 => XAlignment::Left,
+            1 => XAlignment::Center,
+            _ => XAlignment::Right,
+        };
+        let xpos = xpad + xpad * xsquare as f32 + xsquare as f32 * 100.;
+
+        #[cfg(feature = "notan_text")]
+        draw.text(&state.font, &format!["X:{xal:?}"])
+            .position(xpos + 50., 5.0)
+            .color(Color::WHITE)
+            .size(14.0)
+            .alpha(0.7)
+            .h_align_center()
+            .v_align_middle();
+
+        for ysquare in 0..=2 {
+            yal = match ysquare {
+                0 => YAlignment::Top,
+                1 => YAlignment::Center,
+                _ => YAlignment::Bottom,
+            };
+            let ypos = ypad + ypad * ysquare as f32 + ysquare as f32 * 100.;
+
+            // draw each gray rectangle background
+            draw.rect((xpos, ypos), (100.0, 100.0))
+                .fill_color(Color::new(0.3, 0.3, 0.3, 1.));
+
+            #[cfg(feature = "notan_text")]
+            if xsquare == 0 {
+                draw.text(&state.font, &format!["Y:\n{yal:?}"])
+                    .position(0.0, ypos + 50.)
+                    .color(Color::WHITE)
+                    .size(14.0)
+                    .alpha(0.7)
+                    .h_align_left()
+                    .v_align_middle();
+            }
+
+            // draw the inner rectangle points
+            for x in 0..=9 {
+                for y in 0..=9 {
+                    #[cfg(feature = "notan_text")]
+                    if xsquare == 0 && x == 0 {
+                        draw.text(&state.font, &format!["{}", 1 + y])
+                            .position(370., ypos + y as f32 * 10.)
+                            .color(Color::WHITE)
+                            .size(12.0)
+                            .h_align_center()
+                            .v_align_middle();
+                    }
+                    let (x, y) = (x as f32, y as f32);
+
+                    // point increasing in width vertically
+                    draw.point(xpos + x * 10., ypos + y * 10.)
+                        .alpha(0.5)
+                        .width(1.0 + y)
+                        .align(xal, yal)
+                        .color(Color::new(0.9, 0.9, 0.9, 0.9));
+                    // origin point in red
+                    draw.point(xpos + x * 10., ypos + y * 10.)
+                        .alpha(0.5)
+                        .color(Color::RED);
+                }
+            }
+        }
+    }
+    gfx.render(&draw);
+}


### PR DESCRIPTION
Hi! Testing notan I missed being able to draw points in a simple way with variable width and alignment, so I created a Point shape, and two enums for alignment, since it didn't seem appropriate to reuse the ones intended for text.

I also made an example showcasing all the alignment combinations on the first 10 integral widths, showing labels when compiled with text support:

![image](https://github.com/Nazariglez/notan/assets/5832068/62d8aa35-e07d-4c28-b560-d0ca38d8c4ed)

Please feel free of letting me know if you want me to change something.