### PR TITLE
Update egui to 0.27.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,8 +618,16 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03cfe80b1890e1a8cdbffc6044d6872e814aaf6011835a2a5e2db0e5c5c4ef4e"
 dependencies = [
- "bytemuck",
  "serde",
+]
+
+[[package]]
+name = "ecolor"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20930a432bbd57a6d55e07976089708d4893f3d556cf42a0d79e9e321fa73b10"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -630,9 +638,20 @@ checksum = "180f595432a5b615fc6b74afef3955249b86cfea72607b40740a4cd60d5297d0"
 dependencies = [
  "accesskit",
  "ahash",
- "epaint",
+ "epaint 0.26.2",
  "nohash-hasher",
  "serde",
+]
+
+[[package]]
+name = "egui"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584c5d1bf9a67b25778a3323af222dbe1a1feb532190e103901187f92c7fe29a"
+dependencies = [
+ "ahash",
+ "epaint 0.27.2",
+ "nohash-hasher",
 ]
 
 [[package]]
@@ -641,7 +660,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a05f3c8969d21e6a173820ee966387809fe55a14c901ccb35f7975e68b932e5"
 dependencies = [
- "egui",
+ "egui 0.26.2",
  "egui_extras",
  "egui_plot",
  "log",
@@ -654,7 +673,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4a6962241a76da5be5e64e41b851ee1c95fda11f76635522a3c82b119b5475"
 dependencies = [
- "egui",
+ "egui 0.26.2",
  "enum-map",
  "log",
  "mime_guess2",
@@ -667,7 +686,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "803bfcb1ad294dd7f106e26ac9199730d16051496ddb66b10fdb6529eb43df58"
 dependencies = [
- "egui",
+ "egui 0.26.2",
 ]
 
 [[package]]
@@ -682,8 +701,16 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6916301ecf80448f786cdf3eb51d9dbdd831538732229d49119e2d4312eaaf09"
 dependencies = [
- "bytemuck",
  "serde",
+]
+
+[[package]]
+name = "emath"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c3a552cfca14630702449d35f41c84a0d15963273771c6059175a803620f3f"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -735,12 +762,26 @@ checksum = "77b9fdf617dd7f58b0c8e6e9e4a1281f730cde0831d40547da446b2bb76a47af"
 dependencies = [
  "ab_glyph",
  "ahash",
- "bytemuck",
- "ecolor",
- "emath",
+ "ecolor 0.26.2",
+ "emath 0.26.2",
  "nohash-hasher",
  "parking_lot",
  "serde",
+]
+
+[[package]]
+name = "epaint"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b381f8b149657a4acf837095351839f32cd5c4aec1817fc4df84e18d76334176"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "bytemuck",
+ "ecolor 0.27.2",
+ "emath 0.27.2",
+ "nohash-hasher",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1703,10 +1744,10 @@ dependencies = [
 
 [[package]]
 name = "notan_egui"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bytemuck",
- "egui",
+ "egui 0.27.2",
  "log",
  "notan_app",
  "notan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ notan_log = { path = "crates/notan_log", version = "0.12.0" }
 notan_glyph = { path = "crates/notan_glyph", version = "0.12.0" }
 notan_draw = { path = "crates/notan_draw", version = "0.12.0" }
 notan_backend = { path = "crates/notan_backend", version = "0.12.0" }
-notan_egui = { path = "crates/notan_egui", version = "0.12.0" }
+notan_egui = { path = "crates/notan_egui", version = "0.12.1" }
 notan_text = { path = "crates/notan_text", version = "0.12.0" }
 notan_audio = { path = "crates/notan_audio", version = "0.12.0" }
 notan_extra = { path = "crates/notan_extra", version = "0.12.0" }

--- a/crates/notan_egui/Cargo.toml
+++ b/crates/notan_egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notan_egui"
-version.workspace = true
+version = "0.12.1"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -19,7 +19,7 @@ notan_macro.workspace = true
 log.workspace = true
 bytemuck.workspace = true
 
-egui = { version = "0.26.2", features = ["bytemuck"] }
+egui = { version = "0.27.2", features = ["bytemuck"] }
 
 [features]
 links = []

--- a/crates/notan_egui/README.md
+++ b/crates/notan_egui/README.md
@@ -1,7 +1,7 @@
 EGUI
 ===
 
-This is the implementation of [egui 0.22](https://github.com/emilk/egui) for notan.
+This is the implementation of [egui 0.27.2](https://github.com/emilk/egui) for notan.
 
 It should support all the features that __egui__ uses. 
 


### PR DESCRIPTION
This updates notan-egui to use egui 0.27.2, I also separated the version of the notan-egui crate from the workspace version, as I didn't think it made sense to update it when there are no changes to the main crate itself, happy to revert that though and just bump all.