### PR TITLE
Add support for GL_POINTS and gl_PointSize

### DIFF
--- a/crates/notan_glow/src/pipeline.rs
+++ b/crates/notan_glow/src/pipeline.rs
@@ -261,7 +261,7 @@ fn set_srgb_space(gl: &Context, opts: &PipelineOptions) {
 #[inline(always)]
 fn set_point_size_available(gl: &Context, opts: &PipelineOptions) {
     unsafe {
-        if opts.point_size_enabled {
+        if opts.point_size_available {
             gl.enable(glow::VERTEX_PROGRAM_POINT_SIZE);
         } else {
             gl.disable(glow::VERTEX_PROGRAM_POINT_SIZE);

--- a/crates/notan_glow/src/pipeline.rs
+++ b/crates/notan_glow/src/pipeline.rs
@@ -88,6 +88,7 @@ impl InnerPipeline {
             set_blend_mode(gl, options);
             #[cfg(not(target_arch = "wasm32"))]
             set_srgb_space(gl, options);
+            set_point_size_available(gl, options);
         }
     }
 }
@@ -253,6 +254,17 @@ fn set_srgb_space(gl: &Context, opts: &PipelineOptions) {
             gl.enable(glow::FRAMEBUFFER_SRGB);
         } else {
             gl.disable(glow::FRAMEBUFFER_SRGB);
+        }
+    }
+}
+
+#[inline(always)]
+fn set_point_size_available(gl: &Context, opts: &PipelineOptions) {
+    unsafe {
+        if opts.point_size {
+            gl.enable(glow::VERTEX_PROGRAM_POINT_SIZE);
+        } else {
+            gl.disable(glow::VERTEX_PROGRAM_POINT_SIZE);
         }
     }
 }

--- a/crates/notan_glow/src/pipeline.rs
+++ b/crates/notan_glow/src/pipeline.rs
@@ -261,7 +261,7 @@ fn set_srgb_space(gl: &Context, opts: &PipelineOptions) {
 #[inline(always)]
 fn set_point_size_available(gl: &Context, opts: &PipelineOptions) {
     unsafe {
-        if opts.point_size {
+        if opts.point_size_enabled {
             gl.enable(glow::VERTEX_PROGRAM_POINT_SIZE);
         } else {
             gl.disable(glow::VERTEX_PROGRAM_POINT_SIZE);

--- a/crates/notan_glow/src/to_glow.rs
+++ b/crates/notan_glow/src/to_glow.rs
@@ -136,6 +136,7 @@ impl ToGlow for TextureFilter {
 impl ToGlow for DrawPrimitive {
     fn to_glow(&self) -> u32 {
         match self {
+            DrawPrimitive::Points => glow::POINTS,
             DrawPrimitive::Triangles => glow::TRIANGLES,
             DrawPrimitive::TriangleStrip => glow::TRIANGLE_STRIP,
             DrawPrimitive::Lines => glow::LINES,

--- a/crates/notan_graphics/src/pipeline.rs
+++ b/crates/notan_graphics/src/pipeline.rs
@@ -377,7 +377,7 @@ impl Default for PipelineOptions {
             color_mask: Default::default(),
             stencil: None,
             srgb_space: false,
-            point_size_available: false,
+            point_size_available: true,
         }
     }
 }

--- a/crates/notan_graphics/src/pipeline.rs
+++ b/crates/notan_graphics/src/pipeline.rs
@@ -164,7 +164,7 @@ impl<'a, 'b> PipelineBuilder<'a, 'b> {
 
     /// Enable the availability of gl_PointSize in the vertex shader
     pub fn with_point_size_available(mut self, enabled: bool) -> Self {
-        self.options.point_size = enabled;
+        self.options.point_size_enabled = enabled;
         self
     }
 
@@ -364,7 +364,7 @@ pub struct PipelineOptions {
     pub color_mask: ColorMask,
     pub stencil: Option<StencilOptions>,
     pub srgb_space: bool,
-    pub point_size: bool,
+    pub point_size_enabled: bool,
 }
 
 impl Default for PipelineOptions {
@@ -377,7 +377,7 @@ impl Default for PipelineOptions {
             color_mask: Default::default(),
             stencil: None,
             srgb_space: false,
-            point_size: false,
+            point_size_enabled: false,
         }
     }
 }

--- a/crates/notan_graphics/src/pipeline.rs
+++ b/crates/notan_graphics/src/pipeline.rs
@@ -162,6 +162,12 @@ impl<'a, 'b> PipelineBuilder<'a, 'b> {
         self
     }
 
+    /// Enable the availability of gl_PointSize in the vertex shader
+    pub fn with_point_size_available(mut self, enabled: bool) -> Self {
+        self.options.point_size = enabled;
+        self
+    }
+
     /// Build the pipeline with the data set on the builder
     pub fn build(self) -> Result<Pipeline, String> {
         match self.shaders {
@@ -358,6 +364,7 @@ pub struct PipelineOptions {
     pub color_mask: ColorMask,
     pub stencil: Option<StencilOptions>,
     pub srgb_space: bool,
+    pub point_size: bool,
 }
 
 impl Default for PipelineOptions {
@@ -370,6 +377,7 @@ impl Default for PipelineOptions {
             color_mask: Default::default(),
             stencil: None,
             srgb_space: false,
+            point_size: false,
         }
     }
 }
@@ -444,6 +452,7 @@ impl Default for StencilOptions {
 
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum DrawPrimitive {
+    Points,
     Lines,
     LineStrip,
     #[default]

--- a/crates/notan_graphics/src/pipeline.rs
+++ b/crates/notan_graphics/src/pipeline.rs
@@ -164,7 +164,7 @@ impl<'a, 'b> PipelineBuilder<'a, 'b> {
 
     /// Enable the availability of gl_PointSize in the vertex shader
     pub fn with_point_size_available(mut self, enabled: bool) -> Self {
-        self.options.point_size_enabled = enabled;
+        self.options.point_size_available = enabled;
         self
     }
 
@@ -364,7 +364,7 @@ pub struct PipelineOptions {
     pub color_mask: ColorMask,
     pub stencil: Option<StencilOptions>,
     pub srgb_space: bool,
-    pub point_size_enabled: bool,
+    pub point_size_available: bool,
 }
 
 impl Default for PipelineOptions {
@@ -377,7 +377,7 @@ impl Default for PipelineOptions {
             color_mask: Default::default(),
             stencil: None,
             srgb_space: false,
-            point_size_enabled: false,
+            point_size_available: false,
         }
     }
 }


### PR DESCRIPTION
Simple pull request to add support for drawing Points as a primitive as well as support for using `gl_PointSize` in the vertex shader. Sorry if I missed anything, I don't know much about OpenGL. However I've used it in my own toy project and it works (not sure how much of an assurance that is)

Now you should be able to make a pipeline that has gl_PointSize support by doing
```rust
let pipeline = gfx.create_pipeline()
    .from(&VERTEX, &FRAGMENT)
    .with_vertex_info(&vertex_info)
    .with_point_size_available(true) // note
    .build()
    .unwrap();
```
And you should be able to draw points by doing
```rust
renderer.set_primitive(DrawPrimitive::Points);
```