### PR TITLE
fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Here is a simple `index.html` file as an example:
         </style>
     </head>
     <body>
-        <canvas id="notan_canvas"></canvas>
+        <canvas id="notan_app"></canvas>
     </body>
 </html>
 ```


### PR DESCRIPTION
The web example in the README contains the code `<canvas id="notan_canvas">` but Notan actually uses the id `"notan_app"`.  Adding the canvas with the wrong id causes the app to be off center.