### PR TITLE
fix scrolling in example html

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ Here is a simple `index.html` file as an example:
 
             body {
                 display: flex;
-                align-items: center;
-                justify-content: center;
+                align-items: safe center;
+                justify-content: safe center;
             }
         </style>
     </head>

--- a/xtask/res/example.html
+++ b/xtask/res/example.html
@@ -22,8 +22,8 @@
         div#container {
             width: 100%;
             display: flex;
-            align-items: center;
-            justify-content: center;
+            align-items: safe center;
+            justify-content: safe center;
         }
 
         div#source-code {


### PR DESCRIPTION
When using the example html file, if the canvas is larger than the browser window, then scrolling does not work properly.  The top or left of the canvas is cut off.  Adding "safe" to the alignment in the css fixes the issue.

More information here:
https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container