### PR TITLE
Cap InnerBuffer::global_ubo size

### DIFF
--- a/crates/notan_glow/src/buffer.rs
+++ b/crates/notan_glow/src/buffer.rs
@@ -47,7 +47,8 @@ impl InnerBuffer {
 
         #[cfg(target_arch = "wasm32")]
         let global_ubo = if matches!(kind, Kind::Uniform(_, _)) {
-            let max = unsafe { gl.get_parameter_i32(glow::MAX_UNIFORM_BLOCK_SIZE) } as usize;
+            let max = (unsafe { gl.get_parameter_i32(glow::MAX_UNIFORM_BLOCK_SIZE) } as usize)
+                .min(1 << 16);
 
             Some(vec![0; max])
         } else {


### PR DESCRIPTION
The value of glow::MAX_UNIFORM_BLOCK_SIZE can be arbitrarily large. For instance on Firefox on Linux with AMD GPUs tends to generate quite large values: 2\*\*29 on RX 550, and 2\*\*31 on RX 7600 XT, which will result in this function trying to create a 0.5 GB and a 2 GB buffer respectively. Creating buffers this large will either cause a quick OOM, or at least make the application unusably slow.

This commit caps the returned size to 2\*\*16, which is the value returned by Chromium in the same combination as above and results in this function creating 64 kB buffers.