### PR TITLE
add missing dep in egui_custom_font example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,10 @@ name = "egui_basic"
 required-features = ["egui"]
 
 [[example]]
+name = "egui_custom_font"
+required-features = ["egui"]
+
+[[example]]
 name = "egui_demo"
 required-features = ["egui", "links"]
 


### PR DESCRIPTION
This patch fixes an issue where `cargo check --examples` would fail because cargo did not know that egui_custom_font is supposed to be compiled with the egui feature.